### PR TITLE
Replace "NoConnectivity" string

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -22,7 +22,7 @@
     "ExposureNotificationsDisabled": "Exposure notifications are off",
     "ExposureNotificationsDisabledDetailed": "Exposure notifications are needed for COVID Shield to work.",
     "EnableExposureNotificationsCTA": "Turn on exposure notifications",
-    "NoConnectivity": "COVID Shield is offline",
+    "NoConnectivity": "No internet connection",
     "NoConnectivityDetailed": "COVID Shield needs internet access to continue checking for potential exposure.",
     "AppName": "COVID Shield",
     "LastCheckedMinutes": {


### PR DESCRIPTION
Change `NoConnectivity` from "COVID Shield is offline" to "No internet connection" to more clearly reflect situation: exposure notifications and Bluetooth are on, the app is on, but no future exposure checks can occur until there is an internet connection available.

Update to French translation, if needed, will be in separate PR.