### PR TITLE
Replace "NoConnectivity" string (French)

### DIFF
--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -22,7 +22,7 @@
     "ExposureNotificationsDisabled": "Les notifications d'exposition à la COVID-19 sont désactivées",
     "ExposureNotificationsDisabledDetailed": "Les notifications d'exposition à la COVID-19 sont nécessaires au fonctionnement de COVID Shield.",
     "EnableExposureNotificationsCTA": "Activez les notifications d'exposition à la COVID-19",
-    "NoConnectivity": "COVID Shield est hors ligne",
+    "NoConnectivity": "Aucune connexion Internet",
     "NoConnectivityDetailed": "COVID Shield a besoin d'un accès Internet pour continuer de vérifier les expositions potentielles à la COVID-19.",
     "AppName": "COVID Shield",
     "LastCheckedMinutes": {


### PR DESCRIPTION
Change NoConnectivity from "COVID Shield est hors ligne" (COVID Shield is offline) to "Aucune connexion Internet" (No internet connection) to more clearly reflect situation: exposure notifications and Bluetooth are on, the app is on, but no future exposure checks can occur until there is an internet connection available.

English update to same string is PR #8