### PR TITLE
Add "ThankYou" sheet content

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -121,6 +121,11 @@
     "Title": "Privacy policy",
     "Close": "Close"
   },
+  "ThankYou": {
+    "Title": "Thank you for helping",
+    "Body": "Exposure notifications are on. You will receive a notification if COVID Shield detects that you have possibly been exposed to COVID-19.",
+    "Dismiss": "Dismiss"
+  },
   "DataUpload": {
     "Cancel": "Cancel",
     "FormIntro": "Please enter your 8 digit COVID Shield code.",


### PR DESCRIPTION
Add `ThankYou` content for bottom sheet to be displayed one time, post-onboarding. Reassures user that exposure notifications are on, and tells them that COVID Shield will send a notification if it detects that they have possibly been exposed to COVID-19.