### PR TITLE
Fix missing Generated.xcconfig file error on initial build

### DIFF
--- a/ios/Config.debug.xcconfig
+++ b/ios/Config.debug.xcconfig
@@ -1,3 +1,3 @@
-#include "Generated.xcconfig"
+#include? "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-CovidShield/Pods-CovidShield.debug.xcconfig"
 

--- a/ios/Config.release.xcconfig
+++ b/ios/Config.release.xcconfig
@@ -1,2 +1,2 @@
-#include "Generated.xcconfig"
+#include? "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-CovidShield/Pods-CovidShield.release.xcconfig"


### PR DESCRIPTION
On the first build this file does not exist since it is generated in the script phases later.

This is what is recommended in the react-native-config docs https://www.npmjs.com/package/react-native-config#availability-in-build-settings-and-infoplist