### PR TITLE
Persist navigation state in dev

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@
  * @format
  */
 import React, {useMemo, useEffect} from 'react';
-import {NavigationContainer} from '@react-navigation/native';
+import DevPersistedNavigationContainer from 'navigation/DevPersistedNavigationContainer';
 import {I18nContext, I18nManager} from '@shopify/react-i18n';
 import {ThemeProvider} from '@shopify/restyle';
 import MainNavigator from 'navigation/MainNavigator';
@@ -53,7 +53,7 @@ const App = () => {
     <I18nContext.Provider value={i18nManager}>
       <SharedTranslations>
         <ExposureNotificationServiceProvider backendInterface={backendService}>
-          <NavigationContainer>
+          <DevPersistedNavigationContainer persistKey="navigationState">
             {TEST_MODE ? (
               <TestMode>
                 <MainNavigator />
@@ -61,7 +61,7 @@ const App = () => {
             ) : (
               <MainNavigator />
             )}
-          </NavigationContainer>
+          </DevPersistedNavigationContainer>
         </ExposureNotificationServiceProvider>
       </SharedTranslations>
     </I18nContext.Provider>

--- a/src/navigation/DevPersistedNavigationContainer.tsx
+++ b/src/navigation/DevPersistedNavigationContainer.tsx
@@ -1,0 +1,78 @@
+import {InitialState, NavigationContainerRef, NavigationContainer} from '@react-navigation/native';
+import AsyncStorage from '@react-native-community/async-storage';
+import * as React from 'react';
+import {InteractionManager} from 'react-native';
+
+interface DevPersistedNavigationContainerProps extends React.ComponentProps<typeof NavigationContainer> {
+  persistKey: string;
+}
+
+function DevPersistedNavigationContainerImpl(
+  {persistKey, onStateChange, ...others}: DevPersistedNavigationContainerProps,
+  forwardedRef: React.Ref<NavigationContainerRef>,
+) {
+  const [isReady, setIsReady] = React.useState(false);
+  const [initialState, setInitialState] = React.useState<InitialState | undefined>();
+  const persistInteractionRef = React.useRef<{cancel: () => void} | null>(null);
+  const onStateChangeInternal = React.useCallback(
+    state => {
+      const persistState = async () => {
+        persistInteractionRef.current = null;
+        try {
+          await AsyncStorage.setItem(persistKey, JSON.stringify(state));
+        } catch (ex) {
+          console.warn(`Failed to persist state. ${ex.message}`);
+        }
+      };
+
+      if (persistInteractionRef.current !== null) {
+        persistInteractionRef.current.cancel();
+      }
+
+      if (state != null) {
+        persistInteractionRef.current = InteractionManager.runAfterInteractions(persistState);
+      }
+
+      if (onStateChange != null) {
+        onStateChange(state);
+      }
+    },
+    [onStateChange, persistKey],
+  );
+
+  React.useEffect(() => {
+    const loadPerisitedState = async () => {
+      try {
+        const jsonString = await AsyncStorage.getItem(persistKey);
+        if (jsonString != null) {
+          setInitialState(JSON.parse(jsonString));
+        }
+        setIsReady(true);
+      } catch (ex) {
+        console.warn(`Failed to load state. ${ex.message}`);
+        setIsReady(true);
+      }
+    };
+    loadPerisitedState();
+  }, [persistKey]);
+
+  if (!isReady) {
+    return null;
+  }
+
+  return (
+    <NavigationContainer
+      {...others}
+      key={persistKey}
+      ref={forwardedRef}
+      initialState={initialState}
+      onStateChange={onStateChangeInternal}
+    />
+  );
+}
+
+const DevPersistedNavigationContainer = __DEV__
+  ? React.forwardRef(DevPersistedNavigationContainerImpl)
+  : NavigationContainer;
+
+export default DevPersistedNavigationContainer;


### PR DESCRIPTION
This implements state persistence for navigation in development. This means doing a full reload will restore the navigation in the state it was before. Based on https://reactnavigation.org/docs/state-persistence. 

## Test plan

Open the language screen on do a full reload, lang screen reopens.