### PR TITLE
Invalidate EnManager on app reload

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -49,6 +49,12 @@ typedef ENManagerMock ENManagerImplementation ;
   return YES;
 }
 
+- (void)invalidate
+{
+  [self.enManager invalidate];
+  self.enManager = nil;
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_REMAP_METHOD(start, startWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
This fixes a crash when reloading the app on iOS.

## Test plan

Open dev menu -> reload -> no crash 🎉 