### PR TITLE
Autofocus code input

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     ],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'jsx-a11y/no-autofocus': 'off',
   },
   ignorePatterns: [
     '**/services/BackendService/covidshield/*.d.ts',

--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -18,9 +18,10 @@ const inputBorderColor = (string: string, position: number) => {
 export interface CodeInputProps {
   value: string;
   onChange: (value: string) => void;
+  autoFocus?: boolean;
 }
 
-export const CodeInput = ({value, onChange}: CodeInputProps) => {
+export const CodeInput = ({value, onChange, autoFocus}: CodeInputProps) => {
   const inputRef = useRef<TextInput>(null);
   const onChangeTrimmed = useCallback(text => onChange(text.trim()), [onChange]);
 
@@ -62,6 +63,7 @@ export const CodeInput = ({value, onChange}: CodeInputProps) => {
         returnKeyType="done"
         maxLength={8}
         style={styles.input}
+        autoFocus={autoFocus}
       />
       <TouchableWithoutFeedback onPress={giveFocus}>
         <Box flexDirection="row" justifyContent="space-evenly" marginHorizontal="m">

--- a/src/screens/datasharing/views/FormView.tsx
+++ b/src/screens/datasharing/views/FormView.tsx
@@ -34,7 +34,7 @@ export const FormView = ({value, onChange, onSuccess, onError}: FormViewProps) =
         </Text>
       </Box>
       <Box paddingHorizontal="m" marginBottom="m">
-        <CodeInput value={value} onChange={onChange} />
+        <CodeInput value={value} onChange={onChange} autoFocus />
       </Box>
       <Box flex={1} paddingHorizontal="m">
         <Button


### PR DESCRIPTION
I think this improves UX since it is the only input on the screen. There is a lint rule agains the autoFocus prop but I think this is for react web. If there is a reason for not using autofocus here feel free to close this.

![image](https://user-images.githubusercontent.com/2677334/82718227-3ef88a00-9c6f-11ea-95ee-372177e079a7.png)
