### PR TITLE
Set default tint color on iOS

### DIFF
--- a/ios/CovidShield/AppDelegate.m
+++ b/ios/CovidShield/AppDelegate.m
@@ -55,7 +55,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
 didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void (^)(void))completionHandler
-{ 
+{
   [RNCPushNotificationIOS didReceiveNotificationResponse:response];
   completionHandler();
 }
@@ -79,6 +79,9 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  // Sets the default tint color for native components like ActionSheet.
+  // Link blue #002D42
+  self.window.tintColor = [UIColor colorWithRed:2.0f / 255.0f green:120.0f / 255.0f blue:164.0f / 255.0f alpha:1];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
@@ -88,7 +91,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   // [REQUIRED] Register BackgroundFetch
   [[TSBackgroundFetch sharedInstance] didFinishLaunching];
   [RNSplashScreen show];
-  
+
   // Define UNUserNotificationCenter
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
   center.delegate = self;

--- a/ios/CovidShield/AppDelegate.m
+++ b/ios/CovidShield/AppDelegate.m
@@ -79,9 +79,12 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  // #002D42
+  UIColor *linkBlue = [UIColor colorWithRed:2.0f / 255.0f green:120.0f / 255.0f blue:164.0f / 255.0f alpha:1];
   // Sets the default tint color for native components like ActionSheet.
-  // Link blue #002D42
-  self.window.tintColor = [UIColor colorWithRed:2.0f / 255.0f green:120.0f / 255.0f blue:164.0f / 255.0f alpha:1];
+  self.window.tintColor = linkBlue;
+  // This is needed to tint the keyboard done button.
+  UIToolbar.appearance.tintColor = linkBlue;
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;


### PR DESCRIPTION
Sets the default tint color to link blue. This will be used instead of the apple blue which is the default.

## Test plan

For example in the share sheet, see "Edit Actions..."

Before:

![image](https://user-images.githubusercontent.com/2677334/82718950-1757f080-9c74-11ea-9895-d6827bbeff37.png)

After:

![image](https://user-images.githubusercontent.com/2677334/82718974-3eaebd80-9c74-11ea-9eb7-7cb1004e5d9d.png)
