### PR TITLE
Only include Intl polyfill on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,13 @@
+const {Platform} = require('react-native');
+
+// Intl polyfill
+// Needed only on Android when using Hermes since it doesn't yet
+// support Intl. Issue tracking support: https://github.com/facebook/hermes/issues/23.
+// On iOS the minimum version is 10 which has Intl support (https://caniuse.com/#feat=mdn-javascript_builtins_intl).
+if (Platform.OS === 'android' && !global.Intl) {
+  global.Intl = require('intl/lib/core');
+  global.IntlPolyfill = global.Intl;
+  require('intl/locale-data/jsonp/en');
+}
+
 require('./src/index.ts');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 /**
  * @format
  */
-import 'intl';
-import 'intl/locale-data/jsonp/en';
 import 'react-native-gesture-handler';
 
 import AsyncStorage from '@react-native-community/async-storage';


### PR DESCRIPTION
This will avoid including the Intl polyfill in the bundle on iOS. The polyfill is actually only needed when using Hermes on Android so it could be completely removed in case we decide to keep using JSC (#33).

Moved the polyfill to index.js since the file uses require it makes it easier to conditionally require the polyfill. Imports get hoisted so it would not be possible to make sure the intl polyfill code runs before any other code.