### PR TITLE
Fix button and background in onboarding and tutorial screen

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -69,7 +69,9 @@ export const Button = ({
         <ActivityIndicator color={textColor} size="large" />
       ) : (
         <>
-          <Text style={{color: textColor || buttonColor, fontWeight, fontFamily, fontSize}}>{text}</Text>
+          <Text style={{...styles.content, color: textColor || buttonColor, fontWeight, fontFamily, fontSize}}>
+            {text}
+          </Text>
           {externalLink && <Icon name={externalArrowIcon} />}
         </>
       )}
@@ -93,5 +95,8 @@ export const Button = ({
 const styles = StyleSheet.create({
   stretch: {
     alignSelf: 'stretch',
+  },
+  content: {
+    textAlign: 'center',
   },
 });

--- a/src/components/ProgressCircles.tsx
+++ b/src/components/ProgressCircles.tsx
@@ -25,7 +25,7 @@ export const ProgressCircles = ({numberOfSteps, activeStep, ...props}: ProgressC
     return steps;
   };
   return (
-    <Box justifyContent="center" flexDirection="row" marginBottom="l" {...props}>
+    <Box justifyContent="center" flexDirection="row" {...props}>
       {renderSteps()}
     </Box>
   );

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -1,12 +1,11 @@
 import React, {useCallback, useRef, useState} from 'react';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Button, ProgressCircles, Header, LanguageToggle} from 'components';
-import {StyleSheet, useWindowDimensions} from 'react-native';
-import {SafeAreaView, useSafeArea} from 'react-native-safe-area-context';
+import {StyleSheet, LayoutChangeEvent, LayoutRectangle} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import Carousel, {CarouselStatic} from 'react-native-snap-carousel';
 import {useStorage} from 'services/StorageService';
 import {useI18n} from '@shopify/react-i18n';
-import OnboardingBg from 'assets/onboarding-bg.svg';
 import {useMaxContentWidth} from 'shared/useMaxContentWidth';
 
 import {Permissions} from './views/Permissions';
@@ -22,8 +21,6 @@ const viewComponents = {
 
 export const OnboardingScreen = () => {
   const [i18n] = useI18n();
-  const {width: viewportWidth} = useWindowDimensions();
-  const insets = useSafeArea();
   const [currentIndex, setCurrentIndex] = useState(0);
   const carouselRef = useRef(null);
   const {setOnboarded} = useStorage();
@@ -73,27 +70,34 @@ export const OnboardingScreen = () => {
   const BackButton = <Button text={i18n.translate('Onboarding.ActionBack')} variant="subduedText" onPress={prevItem} />;
   const LanguageButton = <LanguageToggle />;
 
+  const [layout, setLayout] = useState<LayoutRectangle | undefined>();
+  const onLayout = useCallback(({nativeEvent: {layout}}: LayoutChangeEvent) => {
+    setLayout(layout);
+  }, []);
+
   return (
     <Box flex={1} backgroundColor="overlayBackground">
-      <Box position="absolute" bottom={50 + insets.bottom} width="100%" opacity={0.4}>
-        <OnboardingBg width="100%" viewBox="0 0 375 325" />
-      </Box>
       <SafeAreaView style={styles.flex}>
         <Header isOverlay />
-        <Carousel
-          ref={carouselRef}
-          data={contentData}
-          renderItem={renderItem}
-          sliderWidth={viewportWidth}
-          itemWidth={viewportWidth}
-          onSnapToItem={newIndex => setCurrentIndex(newIndex)}
-        />
-        <Box alignItems="center" justifyContent="center" flexDirection="row">
-          <Box flex={1} paddingHorizontal="l" paddingBottom="l">
-            {isStart ? LanguageButton : BackButton}
+        <Box flex={1} justifyContent="center" onLayout={onLayout}>
+          {layout && (
+            <Carousel
+              ref={carouselRef}
+              data={contentData}
+              renderItem={renderItem}
+              sliderWidth={layout.width}
+              itemWidth={layout.width}
+              itemHeight={layout.height}
+              onSnapToItem={newIndex => setCurrentIndex(newIndex)}
+            />
+          )}
+        </Box>
+        <Box flexDirection="row" padding="l">
+          <Box flex={1}>{isStart ? LanguageButton : BackButton}</Box>
+          <Box flex={1} justifyContent="center">
+            <ProgressCircles alignSelf="center" numberOfSteps={contentData.length} activeStep={currentIndex + 1} />
           </Box>
-          <ProgressCircles numberOfSteps={contentData.length} activeStep={currentIndex + 1} marginBottom="l" />
-          <Box flex={1} paddingHorizontal="l" paddingBottom="l">
+          <Box flex={1}>
             <Button
               text={i18n.translate(`Onboarding.Action${isEnd ? 'End' : 'Next'}`)}
               variant="text"

--- a/src/screens/onboarding/views/Permissions.tsx
+++ b/src/screens/onboarding/views/Permissions.tsx
@@ -1,34 +1,31 @@
 import React from 'react';
-import {ScrollView} from 'react-native';
 import {Box, Text} from 'components';
 import {useI18n} from '@shopify/react-i18n';
 
 export const Permissions = () => {
   const [i18n] = useI18n();
   return (
-    <ScrollView showsVerticalScrollIndicator={false}>
-      <Box flex={1} paddingHorizontal="xl">
-        <Box paddingHorizontal="l" marginTop="m">
-          <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
-            {i18n.translate('OnboardingPermissions.Title')}
-          </Text>
-        </Box>
-        <Box marginBottom="l">
-          <Text variant="bodyText" color="overlayBodyText" textAlign="center">
-            {i18n.translate('OnboardingPermissions.Body')}
-          </Text>
-        </Box>
-        <Box marginBottom="l">
-          <Text variant="bodyText" color="overlayBodyText" textAlign="center">
-            {i18n.translate('OnboardingPermissions.Body2')}
-          </Text>
-        </Box>
-        <Box marginBottom="l">
-          <Text variant="bodyText" color="overlayBodyText" textAlign="center">
-            {i18n.translate('OnboardingPermissions.Body3')}
-          </Text>
-        </Box>
+    <Box flex={1} paddingHorizontal="xl" justifyContent="center">
+      <Box paddingHorizontal="l" marginTop="m">
+        <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
+          {i18n.translate('OnboardingPermissions.Title')}
+        </Text>
       </Box>
-    </ScrollView>
+      <Box marginBottom="l">
+        <Text variant="bodyText" color="overlayBodyText" textAlign="center">
+          {i18n.translate('OnboardingPermissions.Body')}
+        </Text>
+      </Box>
+      <Box marginBottom="l">
+        <Text variant="bodyText" color="overlayBodyText" textAlign="center">
+          {i18n.translate('OnboardingPermissions.Body2')}
+        </Text>
+      </Box>
+      <Box marginBottom="l">
+        <Text variant="bodyText" color="overlayBodyText" textAlign="center">
+          {i18n.translate('OnboardingPermissions.Body3')}
+        </Text>
+      </Box>
+    </Box>
   );
 };

--- a/src/screens/onboarding/views/Permissions.tsx
+++ b/src/screens/onboarding/views/Permissions.tsx
@@ -1,31 +1,41 @@
 import React from 'react';
+import {ScrollView, StyleSheet} from 'react-native';
 import {Box, Text} from 'components';
 import {useI18n} from '@shopify/react-i18n';
 
 export const Permissions = () => {
   const [i18n] = useI18n();
   return (
-    <Box flex={1} paddingHorizontal="xl" justifyContent="center">
-      <Box paddingHorizontal="l" marginTop="m">
-        <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
-          {i18n.translate('OnboardingPermissions.Title')}
-        </Text>
+    <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.content}>
+      <Box paddingHorizontal="xl">
+        <Box paddingHorizontal="l" marginTop="m">
+          <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
+            {i18n.translate('OnboardingPermissions.Title')}
+          </Text>
+        </Box>
+        <Box marginBottom="l">
+          <Text variant="bodyText" color="overlayBodyText" textAlign="center">
+            {i18n.translate('OnboardingPermissions.Body')}
+          </Text>
+        </Box>
+        <Box marginBottom="l">
+          <Text variant="bodyText" color="overlayBodyText" textAlign="center">
+            {i18n.translate('OnboardingPermissions.Body2')}
+          </Text>
+        </Box>
+        <Box marginBottom="l">
+          <Text variant="bodyText" color="overlayBodyText" textAlign="center">
+            {i18n.translate('OnboardingPermissions.Body3')}
+          </Text>
+        </Box>
       </Box>
-      <Box marginBottom="l">
-        <Text variant="bodyText" color="overlayBodyText" textAlign="center">
-          {i18n.translate('OnboardingPermissions.Body')}
-        </Text>
-      </Box>
-      <Box marginBottom="l">
-        <Text variant="bodyText" color="overlayBodyText" textAlign="center">
-          {i18n.translate('OnboardingPermissions.Body2')}
-        </Text>
-      </Box>
-      <Box marginBottom="l">
-        <Text variant="bodyText" color="overlayBodyText" textAlign="center">
-          {i18n.translate('OnboardingPermissions.Body3')}
-        </Text>
-      </Box>
-    </Box>
+    </ScrollView>
   );
 };
+
+const styles = StyleSheet.create({
+  content: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/onboarding/views/Start.tsx
+++ b/src/screens/onboarding/views/Start.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {ScrollView, StyleSheet} from 'react-native';
 import {Box, Text, Button, Icon} from 'components';
 import {useNavigation} from '@react-navigation/native';
 import {useI18n} from '@shopify/react-i18n';
@@ -7,31 +8,40 @@ export const Start = () => {
   const [i18n] = useI18n();
   const navigation = useNavigation();
   return (
-    <Box flex={1} paddingHorizontal="xl" justifyContent="center">
-      <Box paddingHorizontal="l" marginTop="m">
-        <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
-          {i18n.translate('OnboardingStart.Title')}
-        </Text>
+    <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.content}>
+      <Box paddingHorizontal="xl">
+        <Box paddingHorizontal="l" marginTop="m">
+          <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
+            {i18n.translate('OnboardingStart.Title')}
+          </Text>
+        </Box>
+        <Box flexDirection="row" alignItems="center" marginBottom="l">
+          <Icon size={30} name="icon-notifications" />
+          <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
+            {i18n.translate('OnboardingStart.Body1')}
+          </Text>
+        </Box>
+        <Box flexDirection="row" alignItems="center" marginBottom="l">
+          <Icon size={30} name="icon-notify" />
+          <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
+            {i18n.translate('OnboardingStart.Body2')}
+          </Text>
+        </Box>
+        <Box flexDirection="row" justifyContent="space-around" alignItems="center" marginBottom="l">
+          <Button
+            text={i18n.translate('OnboardingStart.TutorialAction')}
+            variant="bigFlatWhite"
+            onPress={() => navigation.navigate('Tutorial')}
+          />
+        </Box>
       </Box>
-      <Box flexDirection="row" alignItems="center" marginBottom="l">
-        <Icon size={30} name="icon-notifications" />
-        <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
-          {i18n.translate('OnboardingStart.Body1')}
-        </Text>
-      </Box>
-      <Box flexDirection="row" alignItems="center" marginBottom="l">
-        <Icon size={30} name="icon-notify" />
-        <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
-          {i18n.translate('OnboardingStart.Body2')}
-        </Text>
-      </Box>
-      <Box flexDirection="row" justifyContent="space-around" alignItems="center" marginBottom="l">
-        <Button
-          text={i18n.translate('OnboardingStart.TutorialAction')}
-          variant="bigFlatWhite"
-          onPress={() => navigation.navigate('Tutorial')}
-        />
-      </Box>
-    </Box>
+    </ScrollView>
   );
 };
+
+const styles = StyleSheet.create({
+  content: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/onboarding/views/Start.tsx
+++ b/src/screens/onboarding/views/Start.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {ScrollView} from 'react-native';
 import {Box, Text, Button, Icon} from 'components';
 import {useNavigation} from '@react-navigation/native';
 import {useI18n} from '@shopify/react-i18n';
@@ -8,33 +7,31 @@ export const Start = () => {
   const [i18n] = useI18n();
   const navigation = useNavigation();
   return (
-    <ScrollView showsVerticalScrollIndicator={false}>
-      <Box flex={1} paddingHorizontal="xl">
-        <Box paddingHorizontal="l" marginTop="m">
-          <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
-            {i18n.translate('OnboardingStart.Title')}
-          </Text>
-        </Box>
-        <Box flexDirection="row" alignItems="center" marginBottom="l">
-          <Icon size={30} name="icon-notifications" />
-          <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
-            {i18n.translate('OnboardingStart.Body1')}
-          </Text>
-        </Box>
-        <Box flexDirection="row" alignItems="center" marginBottom="l">
-          <Icon size={30} name="icon-notify" />
-          <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
-            {i18n.translate('OnboardingStart.Body2')}
-          </Text>
-        </Box>
-        <Box flexDirection="row" justifyContent="space-around" alignItems="center" marginBottom="l">
-          <Button
-            text={i18n.translate('OnboardingStart.TutorialAction')}
-            variant="bigFlatWhite"
-            onPress={() => navigation.navigate('Tutorial')}
-          />
-        </Box>
+    <Box flex={1} paddingHorizontal="xl" justifyContent="center">
+      <Box paddingHorizontal="l" marginTop="m">
+        <Text variant="bodyTitle" color="overlayBodyText" marginHorizontal="l" marginBottom="l" textAlign="center">
+          {i18n.translate('OnboardingStart.Title')}
+        </Text>
       </Box>
-    </ScrollView>
+      <Box flexDirection="row" alignItems="center" marginBottom="l">
+        <Icon size={30} name="icon-notifications" />
+        <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
+          {i18n.translate('OnboardingStart.Body1')}
+        </Text>
+      </Box>
+      <Box flexDirection="row" alignItems="center" marginBottom="l">
+        <Icon size={30} name="icon-notify" />
+        <Text variant="bodyText" color="overlayBodyText" marginLeft="m" marginRight="m">
+          {i18n.translate('OnboardingStart.Body2')}
+        </Text>
+      </Box>
+      <Box flexDirection="row" justifyContent="space-around" alignItems="center" marginBottom="l">
+        <Button
+          text={i18n.translate('OnboardingStart.TutorialAction')}
+          variant="bigFlatWhite"
+          onPress={() => navigation.navigate('Tutorial')}
+        />
+      </Box>
+    </Box>
   );
 };

--- a/src/screens/tutorial/Tutorial.tsx
+++ b/src/screens/tutorial/Tutorial.tsx
@@ -71,14 +71,16 @@ export const TutorialScreen = () => {
             onSnapToItem={newIndex => setCurrentStep(newIndex)}
           />
         )}
-        <Box alignItems="center" justifyContent="center" flexDirection="row" flexWrap="wrap">
-          <Box flex={1} padding="l" flexWrap="wrap">
+        <Box flexDirection="row" padding="l">
+          <Box flex={1}>
             {!isStart && (
               <Button text={i18n.translate(`Tutorial.ActionBack`)} variant="subduedText" onPress={prevItem} />
             )}
           </Box>
-          <ProgressCircles numberOfSteps={tutorialData.length} activeStep={currentStep + 1} marginBottom="none" />
-          <Box flex={1} padding="l" flexWrap="wrap">
+          <Box flex={1} justifyContent="center">
+            <ProgressCircles numberOfSteps={tutorialData.length} activeStep={currentStep + 1} marginBottom="none" />
+          </Box>
+          <Box flex={1}>
             <Button
               text={i18n.translate(`Tutorial.Action${isEnd ? 'End' : 'Next'}`)}
               variant="text"


### PR DESCRIPTION
This PR fixes Next button alignment in both Onboarding and Tutorial screen. It also removes background image in boarding screen.

Resolves:
- https://github.com/CovidShield/mobile/issues/59
- https://github.com/CovidShield/mobile/issues/61

<img src="https://user-images.githubusercontent.com/5274722/83211955-5da5c780-a12c-11ea-9f4b-21aa12bc57a5.png" width="240" />
<img src="https://user-images.githubusercontent.com/5274722/83211959-60082180-a12c-11ea-9d72-a545b3d4bbb4.png" width="240" />
<img src="https://user-images.githubusercontent.com/5274722/83211961-61d1e500-a12c-11ea-8e6f-39678f8c2d93.png" width="240" />
<img src="https://user-images.githubusercontent.com/5274722/83211965-639ba880-a12c-11ea-8ed9-e4d250696aa6.png" width="240" />

