### PR TITLE
Fix EN framework start-up

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -66,7 +66,13 @@ RCT_REMAP_METHOD(start, startWithResolver:(RCTPromiseResolveBlock)resolve reject
     if (error) {
       reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
     } else {
-      resolve(nil);
+      [self.enManager setExposureNotificationEnabled:YES completionHandler:^(NSError * _Nullable error) {
+        if (error) {
+          reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
+        } else {
+          resolve(nil);
+        }
+      }];
     }
   }];
 }
@@ -95,6 +101,27 @@ RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolv
       break;
   }
 }
+
+
+RCT_REMAP_METHOD(getTestTemporaryExposureKeyHistory, getTestTemporaryExposureKeyHistoryWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self.enManager getTestDiagnosisKeysWithCompletionHandler:^(NSArray<ENTemporaryExposureKey *> * _Nullable keys, NSError * _Nullable error) {
+    if (error) {
+      reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
+    } else {
+      NSMutableArray *serialziedKeys = [NSMutableArray new];
+      for (ENTemporaryExposureKey *key in keys) {
+        [serialziedKeys addObject:@{
+          @"keyData": [key.keyData base64EncodedStringWithOptions:0],
+          @"rollingStartNumber": @(key.rollingStartNumber),
+          @"transmissionRiskLevel": @(key.transmissionRiskLevel)
+        }];
+      }
+      resolve(serialziedKeys);
+    }
+  }];
+}
+
 
 RCT_REMAP_METHOD(getTemporaryExposureKeyHistory, getTemporaryExposureKeyHistoryWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -102,27 +102,6 @@ RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolv
   }
 }
 
-
-RCT_REMAP_METHOD(getTestTemporaryExposureKeyHistory, getTestTemporaryExposureKeyHistoryWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-{
-  [self.enManager getTestDiagnosisKeysWithCompletionHandler:^(NSArray<ENTemporaryExposureKey *> * _Nullable keys, NSError * _Nullable error) {
-    if (error) {
-      reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
-    } else {
-      NSMutableArray *serialziedKeys = [NSMutableArray new];
-      for (ENTemporaryExposureKey *key in keys) {
-        [serialziedKeys addObject:@{
-          @"keyData": [key.keyData base64EncodedStringWithOptions:0],
-          @"rollingStartNumber": @(key.rollingStartNumber),
-          @"transmissionRiskLevel": @(key.transmissionRiskLevel)
-        }];
-      }
-      resolve(serialziedKeys);
-    }
-  }];
-}
-
-
 RCT_REMAP_METHOD(getTemporaryExposureKeyHistory, getTemporaryExposureKeyHistoryWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   [self.enManager getDiagnosisKeysWithCompletionHandler:^(NSArray<ENTemporaryExposureKey *> * _Nullable keys, NSError * _Nullable error) {

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import React, {useMemo, useState, useEffect} from 'react';
 import {AppState, AppStateStatus, DevSettings} from 'react-native';
 import {BottomSheet, Box} from 'components';
-import {useExposureStatus, useSystemStatus, SystemStatus} from 'services/ExposureNotificationService';
+import {useExposureStatus, useSystemStatus, SystemStatus, useStartENSystem} from 'services/ExposureNotificationService';
 import {checkNotifications, requestNotifications} from 'react-native-permissions';
 import {useNetInfo} from '@react-native-community/netinfo';
 import {useNavigation, DrawerActions} from '@react-navigation/native';
@@ -46,6 +46,11 @@ const useNotificationPermissionStatus = (): [string, () => void] => {
 const Content = () => {
   const [exposureStatus, updateExposureStatus] = useExposureStatus();
   const [systemStatus, updateSystemStatus] = useSystemStatus();
+  const startSystem = useStartENSystem();
+
+  useEffect(() => {
+    startSystem();
+  }, [startSystem]);
 
   const network = useNetInfo();
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -53,6 +53,7 @@ export interface SecureStorageOptions {
 export class ExposureNotificationService {
   systemStatus: Observable<SystemStatus>;
   exposureStatus: Observable<ExposureStatus>;
+  started = false;
 
   exposureNotification: typeof ExposureNotification;
   backendInterface: BackendInterface;
@@ -77,10 +78,10 @@ export class ExposureNotificationService {
     this.backendInterface = backendInterface;
     this.storage = storage;
     this.secureStorage = secureStorage;
-    this.start();
   }
 
   async start(): Promise<void> {
+    this.started = true;
     try {
       await this.exposureNotification.start();
     } catch (_) {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -59,6 +59,15 @@ export const ExposureNotificationServiceProvider = ({
   );
 };
 
+export function useStartENSystem(): () => void {
+  const exposureNotificationService = useContext(ExposureNotificationServiceContext)!;
+  return useCallback(() => {
+    if (!exposureNotificationService.started) {
+      exposureNotificationService.start();
+    }
+  }, [exposureNotificationService]);
+}
+
 export function useSystemStatus(): [SystemStatus, () => void] {
   const exposureNotificationService = useContext(ExposureNotificationServiceContext)!;
   const [state, setState] = useState<SystemStatus>(exposureNotificationService.systemStatus.value);


### PR DESCRIPTION
We were not calling `setExposureNotificationEnabled` which is a required to step to enable the framework on iOS. 
Once fixed, I realized we start up EN stack at app paunch which isn't ideal, since we need to get user a chance to go through onboarding messaging first. I moved start up to later, when onboarding is finished.