### PR TITLE
Fix test mode reset data

### DIFF
--- a/src/services/StorageService/StorageServiceProvider.tsx
+++ b/src/services/StorageService/StorageServiceProvider.tsx
@@ -1,5 +1,6 @@
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import AsyncStorage from '@react-native-community/async-storage';
+import {DevSettings} from 'react-native';
 
 import {StorageService} from './StorageService';
 
@@ -34,11 +35,14 @@ export const useStorage = () => {
   useEffect(() => storageService.locale.observe(setLocaleInternal), [storageService.locale]);
   useEffect(() => storageService.region.observe(setRegionInternal), [storageService.region]);
 
-  const reset = useCallback(() => {
+  const reset = useCallback(async () => {
     setOnboarded(false);
     setLocale('en');
     setRegion(undefined);
-    AsyncStorage.clear();
+    await AsyncStorage.clear();
+    if (__DEV__) {
+      DevSettings.reload('Reset app');
+    }
   }, [setLocale, setOnboarded, setRegion]);
 
   return useMemo(

--- a/src/testMode/TestMode.tsx
+++ b/src/testMode/TestMode.tsx
@@ -119,7 +119,7 @@ const DrawerContent = () => {
           <Item title="JavaScript engine" connectedRight={(global as any).HermesInternal == null ? 'JSC' : 'Hermes'} />
         </Section>
         <Section>
-          <Item title="Clear data" subtitle="Still need to reopen the app manually" onPress={reset} />
+          <Item title="Clear data" onPress={reset} />
         </Section>
       </Box>
     </DrawerContentScrollView>


### PR DESCRIPTION
Because of navigation persistance the reset app dev action does not work well since it will clear data but return to the main app still.

A good workaround I found is to reload the app immediately after clearing storage. We can also now remove the message that says you need to reload the app manually. 