### PR TITLE
Update react-native-safe-area-context

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -243,7 +243,7 @@ PODS:
     - React
   - react-native-netinfo (5.9.0):
     - React
-  - react-native-safe-area-context (2.0.0):
+  - react-native-safe-area-context (3.0.2):
     - React
   - react-native-sensitive-info (5.5.5):
     - React
@@ -533,7 +533,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
   react-native-config: 313a1306066289211579b9655eb81d9a565462d0
   react-native-netinfo: 7b3c53674ea611b26a7788821f137c6d9d3a038b
-  react-native-safe-area-context: 60f654e00b6cc416573f6d5dbfce3839958eb57a
+  react-native-safe-area-context: b11a34881faac509cad5578726c98161ad4d275c
   react-native-sensitive-info: 4629b223484a08225c3eb088ff3f91b03097b5e5
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-native-material-ripple": "^0.9.1",
     "react-native-permissions": "^2.1.4",
     "react-native-reanimated": "^1.8.0",
-    "react-native-safe-area-context": "^2.0.0",
+    "react-native-safe-area-context": "^3.0.2",
     "react-native-screens": "^2.7.0",
     "react-native-sensitive-info": "^5.5.5",
     "react-native-share": "^3.3.0",

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -12,6 +12,7 @@ import {OnboardingScreen} from 'screens/onboarding';
 import {LanguageScreen} from 'screens/language';
 import {useStorage} from 'services/StorageService';
 import {RegionPickerScreen} from 'screens/regionPicker';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 enableScreens();
 
@@ -21,7 +22,7 @@ const withDarkNav = (Component: React.ElementType) => {
   const ComponentWithDarkNav = (props: any) => {
     const stackIndex = useNavigationState(state => state.index);
     return (
-      <>
+      <SafeAreaProvider>
         <StatusBar
           barStyle={
             // On iOS 13+ keep light statusbar since the screen will be displayed in a modal with a
@@ -32,17 +33,18 @@ const withDarkNav = (Component: React.ElementType) => {
           }
         />
         <Component {...props} />
-      </>
+      </SafeAreaProvider>
     );
   };
   return ComponentWithDarkNav;
 };
+
 const withLightNav = (Component: React.ElementType) => {
   const ComponentWithLightNav = (props: any) => (
-    <>
+    <SafeAreaProvider>
       <StatusBar barStyle="light-content" />
       <Component {...props} />
-    </>
+    </SafeAreaProvider>
   );
   return ComponentWithLightNav;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7257,10 +7257,10 @@ react-native-reanimated@^1.8.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-2.0.0.tgz#7ef48e5a83a1e2f7fe9d5321493822b6765fd1ab"
-  integrity sha512-5VtCI3Nluzm7QfTcB/3j4YeWqt25QO1u5KTA1jEg1ckJzV19qCZFyHIpCCkS5+VEX+2JEHfdczhCdwE5sPgyEw==
+react-native-safe-area-context@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.0.2.tgz#95dd7e56bc89bcc4f3f7bb5fada30c98420328b2"
+  integrity sha512-x3yVMsxwe9GyvIkv0Q5jy2CWYN7VO0/CJTFGG5kSiMo8FFTQJbWtuWGANFqxDzEH5NEV7/SfK+qTgAh931KyUw==
 
 react-native-safe-modules@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The main change is that SafeAreaView is now relative to the nearest provider so we wrap each screen with a provider so we get proper insets in iOS 13 modals.

Tested that insets looked fine on an iphone 11 by going through all screens.