### PR TITLE
Add autofocus if screen reader is false

### DIFF
--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useRef} from 'react';
 import {TextInput, TouchableWithoutFeedback, StyleSheet} from 'react-native';
+import {useScreenReaderEnabled} from 'shared/useScreenReaderEnabled';
 
 import {Box} from './Box';
 import {Text} from './Text';
@@ -22,6 +23,7 @@ export interface CodeInputProps {
 }
 
 export const CodeInput = ({value, onChange, accessibilityLabel}: CodeInputProps) => {
+  const screenReaderEnabled = useScreenReaderEnabled();
   const inputRef = useRef<TextInput>(null);
   const onChangeTrimmed = useCallback(text => onChange(text.trim()), [onChange]);
 
@@ -65,6 +67,7 @@ export const CodeInput = ({value, onChange, accessibilityLabel}: CodeInputProps)
         caretHidden
         maxLength={8}
         style={styles.input}
+        autoFocus={!screenReaderEnabled}
       />
       <TouchableWithoutFeedback
         onPress={giveFocus}

--- a/src/shared/useScreenReaderEnabled.ts
+++ b/src/shared/useScreenReaderEnabled.ts
@@ -1,0 +1,21 @@
+import {useEffect, useState} from 'react';
+import {AccessibilityInfo, AccessibilityEvent} from 'react-native';
+
+export function useScreenReaderEnabled() {
+  const [screenReaderEnabled, setEnabled] = useState(false);
+  useEffect(() => {
+    const handleChange = (isScreenReaderEnabled: AccessibilityEvent) => {
+      setEnabled(Boolean(isScreenReaderEnabled));
+    };
+    AccessibilityInfo.isScreenReaderEnabled()
+      .then(handleChange)
+      .catch(error => {
+        console.warn('AccessibilityInfo.isScreenReaderEnabled promise failed', error);
+      });
+    AccessibilityInfo.addEventListener('screenReaderChanged', handleChange);
+    return () => {
+      AccessibilityInfo.removeEventListener('screenReaderChanged', handleChange);
+    };
+  }, []);
+  return screenReaderEnabled;
+}


### PR DESCRIPTION
Enables autofocus unless user has a Screen Reader Enabled. 

I couldn't actually test this as enabling the Accessibility Debug menu on the simulator doesn't actually trigger the isScreenReaderEnabled setting.

Probably need to test this on an actual device.