### PR TITLE
Disable application prefix for debug build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,7 +154,7 @@ android {
     }
     buildTypes {
         debug {
-            applicationIdSuffix ".debug"
+            minifyEnabled false
         }
         release {
             minifyEnabled enableProguardInReleaseBuilds


### PR DESCRIPTION
Because package name in Android needs to be whitelisted, it is annoying to automatically add prefix to package name.