### PR TITLE
Show EN dialog at the end of onboarding flow

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,7 +1,12 @@
 import React, {useMemo, useState, useEffect} from 'react';
 import {AppState, AppStateStatus, DevSettings} from 'react-native';
 import {BottomSheet, Box} from 'components';
-import {useExposureStatus, useSystemStatus, SystemStatus, useStartENSystem} from 'services/ExposureNotificationService';
+import {
+  useExposureStatus,
+  useSystemStatus,
+  SystemStatus,
+  useStartExposureNotificationService,
+} from 'services/ExposureNotificationService';
 import {checkNotifications, requestNotifications} from 'react-native-permissions';
 import {useNetInfo} from '@react-native-community/netinfo';
 import {useNavigation, DrawerActions} from '@react-navigation/native';
@@ -47,11 +52,11 @@ const useNotificationPermissionStatus = (): [string, () => void] => {
 const Content = () => {
   const [exposureStatus, updateExposureStatus] = useExposureStatus();
   const [systemStatus, updateSystemStatus] = useSystemStatus();
-  const startSystem = useStartENSystem();
+  const startExposureNotificationService = useStartExposureNotificationService();
 
   useEffect(() => {
-    startSystem();
-  }, [startSystem]);
+    startExposureNotificationService();
+  }, [startExposureNotificationService]);
 
   const network = useNetInfo();
 

--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -1,17 +1,17 @@
 import {useI18n} from '@shopify/react-i18n';
 import {Box, Button, Icon, LastCheckedDisplay, Text} from 'components';
 import React, {useCallback} from 'react';
-import {useStartENSystem} from 'services/ExposureNotificationService';
+import {useStartExposureNotificationService} from 'services/ExposureNotificationService';
 
 import {BaseHomeView} from '../components/BaseHomeView';
 
 export const ExposureNotificationsDisabledView = () => {
   const [i18n] = useI18n();
-  const startSystem = useStartENSystem();
+  const startExposureNotificationService = useStartExposureNotificationService();
 
   const enableExposureNotifications = useCallback(() => {
-    startSystem();
-  }, [startSystem]);
+    startExposureNotificationService();
+  }, [startExposureNotificationService]);
 
   return (
     <BaseHomeView>

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -1,11 +1,12 @@
 import React, {useCallback, useRef, useState} from 'react';
 import {useNavigation} from '@react-navigation/native';
-import {Box, Button, ProgressCircles, Header, LanguageToggle} from 'components';
-import {StyleSheet, LayoutChangeEvent, LayoutRectangle} from 'react-native';
+import {useI18n} from '@shopify/react-i18n';
+import {Box, Button, Header, LanguageToggle, ProgressCircles} from 'components';
+import {LayoutChangeEvent, LayoutRectangle, StyleSheet} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import Carousel, {CarouselStatic} from 'react-native-snap-carousel';
+import {useStartExposureNotificationService} from 'services/ExposureNotificationService';
 import {useStorage} from 'services/StorageService';
-import {useI18n} from '@shopify/react-i18n';
 import {useMaxContentWidth} from 'shared/useMaxContentWidth';
 
 import {Permissions} from './views/Permissions';
@@ -25,14 +26,16 @@ export const OnboardingScreen = () => {
   const carouselRef = useRef(null);
   const {setOnboarded} = useStorage();
   const navigation = useNavigation();
-  const handlePermissions = useCallback(() => {
-    // handle all our app permission stuff
+  const startExposureNotificationService = useStartExposureNotificationService();
+
+  const handlePermissions = useCallback(async () => {
+    await startExposureNotificationService();
     setOnboarded(true);
     navigation.reset({
       index: 0,
       routes: [{name: 'Home'}],
     });
-  }, [navigation, setOnboarded]);
+  }, [navigation, setOnboarded, startExposureNotificationService]);
 
   const maxWidth = useMaxContentWidth();
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-atomic-updates */
 import {when} from 'jest-when';
 
-import {ExposureNotificationService} from './ExposureNotificationService';
+import {ExposureNotificationService, SystemStatus} from './ExposureNotificationService';
 
 const server: any = {
   retrieveDiagnosisKeys: jest.fn().mockResolvedValue([]),
@@ -22,6 +22,7 @@ const bridge: any = {
   detectExposure: jest.fn().mockResolvedValue({matchedKeyCount: 0}),
   start: jest.fn().mockResolvedValue(undefined),
   getTemporaryExposureKeyHistory: jest.fn().mockResolvedValue({}),
+  getStatus: jest.fn(),
 };
 
 describe('ExposureNotificationService', () => {
@@ -29,8 +30,10 @@ describe('ExposureNotificationService', () => {
 
   const OriginalDate = global.Date;
   const dateSpy = jest.spyOn(global, 'Date');
+
   beforeEach(() => {
     service = new ExposureNotificationService(server, translate, storage, secureStorage, bridge);
+    bridge.getStatus.mockReturnValue(Promise.resolve(SystemStatus.Active));
   });
 
   afterEach(() => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -85,12 +85,12 @@ export class ExposureNotificationService {
   async start(): Promise<void> {
     try {
       await this.exposureNotification.start();
-      await this.updateSystemStatus();
     } catch (_) {
       // Noop because Exposure Notification framework is unavailable on device
       return;
     }
 
+    await this.updateSystemStatus();
     if (this.systemStatus.get() !== SystemStatus.Active) {
       // Noop because Exposure Notification cannot start
       return;

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -83,23 +83,25 @@ export class ExposureNotificationService {
   }
 
   async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
     try {
       await this.exposureNotification.start();
     } catch (_) {
       // Noop because Exposure Notification framework is unavailable on device
+      this.started = false;
       return;
     }
 
     await this.updateSystemStatus();
     if (this.systemStatus.get() !== SystemStatus.Active) {
       // Noop because Exposure Notification cannot start
+      this.started = false;
       return;
     }
-
-    if (this.started) {
-      return;
-    }
-    this.started = true;
 
     // we check the lastCheckTimeStamp on start to make sure it gets populated even if the server doesn't run
     const timestamp = await this.storage.getItem('lastCheckTimeStamp');

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -53,7 +53,6 @@ export interface SecureStorageOptions {
 export class ExposureNotificationService {
   systemStatus: Observable<SystemStatus>;
   exposureStatus: Observable<ExposureStatus>;
-  started = false;
 
   exposureNotification: typeof ExposureNotification;
   backendInterface: BackendInterface;
@@ -63,6 +62,7 @@ export class ExposureNotificationService {
   secureStorage: SecurePersistencyProvider;
 
   private exposureStatusUpdatePromise: Promise<ExposureStatus> | null = null;
+  private started = false;
 
   constructor(
     backendInterface: BackendInterface,
@@ -78,16 +78,29 @@ export class ExposureNotificationService {
     this.backendInterface = backendInterface;
     this.storage = storage;
     this.secureStorage = secureStorage;
+    // initialize
+    this.updateSystemStatus();
   }
 
   async start(): Promise<void> {
-    this.started = true;
     try {
       await this.exposureNotification.start();
+      await this.updateSystemStatus();
     } catch (_) {
       // Noop because Exposure Notification framework is unavailable on device
       return;
     }
+
+    if (this.systemStatus.get() !== SystemStatus.Active) {
+      // Noop because Exposure Notification cannot start
+      return;
+    }
+
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
     // we check the lastCheckTimeStamp on start to make sure it gets populated even if the server doesn't run
     const timestamp = await this.storage.getItem('lastCheckTimeStamp');
     const submissionCycleStartedAtStr = await this.storage.getItem(SUBMISSION_CYCLE_STARTED_AT);

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -59,12 +59,10 @@ export const ExposureNotificationServiceProvider = ({
   );
 };
 
-export function useStartENSystem(): () => void {
+export function useStartExposureNotificationService(): () => Promise<void> {
   const exposureNotificationService = useContext(ExposureNotificationServiceContext)!;
-  return useCallback(() => {
-    if (!exposureNotificationService.started) {
-      exposureNotificationService.start();
-    }
+  return useCallback(async () => {
+    await exposureNotificationService.start();
   }, [exposureNotificationService]);
 }
 


### PR DESCRIPTION
This PR does two things:
- Show EN dialog at the end of onboarding flow. 
- Attempt to fix flashing system status when open the app. Although there is still on flashing due to internet check but it should be in a follow up PR. 

### How to test: 
- Change APP_ID_ANDROID to `com.google.android.apps.exposurenotification`.
- Run the app. 
- Verify:
  + A consent dialog is shown at the end of onboarding flow.
  + System status is updated properly when disable EN in settings and resume the app. 
  + Able to re-enable EN in app after disabling EN in settings.

### Demo:

https://drive.google.com/file/d/17wJ_1b7zrIcOcaC-ycgaIfwfUzjLsWbt/view?usp=sharing

Resolves https://github.com/CovidShield/mobile/issues/117 and https://github.com/CovidShield/mobile/issues/118