### PR TITLE
Fix submission flow on Android

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ APP_VERSION_NAME=1.0
 SUBMIT_URL=https://submission.covidshield.app
 RETRIEVE_URL=https://retrieval.covidshield.app
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+REGION=302
 
 TEST_MODE=true
 MOCK_SERVER=false

--- a/.env.production
+++ b/.env.production
@@ -6,6 +6,7 @@ APP_VERSION_NAME=1.0
 SUBMIT_URL=https://submission.covidshield.app
 RETRIEVE_URL=https://retrieval.covidshield.app
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+REGION=302
 
 TEST_MODE=false
 MOCK_SERVER=false

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-feature
         android:name="android.hardware.bluetooth_le"
         android:required="true" />
+    <uses-feature android:name="android.hardware.bluetooth" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/android/app/src/main/java/app/covidshield/extensions/PromiseExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/PromiseExtensions.kt
@@ -5,15 +5,6 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@Deprecated("Remove later")
-fun Promise.rejectOnException(block: () -> Unit) {
-    return try {
-        block.invoke()
-    } catch (e: Exception) {
-        reject(e)
-    }
-}
-
 fun Promise.launch(scope: CoroutineScope, block: suspend CoroutineScope.() -> Unit) {
     scope.launch(
         context = CoroutineExceptionHandler { _, exception ->

--- a/android/app/src/main/java/app/covidshield/extensions/ReactNativeExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/ReactNativeExtensions.kt
@@ -12,7 +12,9 @@ import org.json.JSONException
 import org.json.JSONObject
 
 fun List<Any>.toWritableArray(): WritableArray {
-    return convertJsonToArray(this.toJson().parse(JSONArray::class.java))
+    val writableArray = WritableNativeArray()
+    forEach { writableArray.pushMap(it.toWritableMap()) }
+    return writableArray
 }
 
 fun Any.toWritableMap(): WritableMap {

--- a/android/app/src/main/java/app/covidshield/extensions/TemporaryExposureKeyExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/TemporaryExposureKeyExtensions.kt
@@ -1,14 +1,13 @@
 package app.covidshield.extensions
 
+import android.util.Base64
 import app.covidshield.models.ExposureKey
-import com.google.android.gms.common.util.Hex
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 
 fun TemporaryExposureKey.toExposureKey(): ExposureKey {
     return ExposureKey(
-        keyData = Hex.bytesToStringLowercase(keyData),
+        keyData = Base64.encodeToString(keyData, Base64.NO_WRAP),
         rollingStartNumber = rollingStartIntervalNumber,
-        rollingDuration = rollingStartIntervalNumber,
         rollingPeriod = rollingPeriod,
         transmissionRiskLevel = transmissionRiskLevel
     )

--- a/android/app/src/main/java/app/covidshield/extensions/TemporaryExposureKeyExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/TemporaryExposureKeyExtensions.kt
@@ -6,9 +6,10 @@ import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 
 fun TemporaryExposureKey.toExposureKey(): ExposureKey {
     return ExposureKey(
-        transmissionRiskLevel = transmissionRiskLevel,
         keyData = Hex.bytesToStringLowercase(keyData),
         rollingStartNumber = rollingStartIntervalNumber,
-        rollingStartIntervalNumber = rollingStartIntervalNumber
+        rollingDuration = rollingStartIntervalNumber,
+        rollingPeriod = rollingPeriod,
+        transmissionRiskLevel = transmissionRiskLevel
     )
 }

--- a/android/app/src/main/java/app/covidshield/models/ExposureKey.kt
+++ b/android/app/src/main/java/app/covidshield/models/ExposureKey.kt
@@ -3,8 +3,9 @@ package app.covidshield.models
 import com.google.gson.annotations.SerializedName
 
 data class ExposureKey(
-    @SerializedName("transmissionRiskLevel") val transmissionRiskLevel: Int,
     @SerializedName("keyData") val keyData: String,
     @SerializedName("rollingStartNumber") val rollingStartNumber: Int,
-    @SerializedName("rollingStartIntervalNumber") val rollingStartIntervalNumber: Int
+    @SerializedName("rollingDuration") val rollingDuration: Int,
+    @SerializedName("rollingPeriod") val rollingPeriod: Int,
+    @SerializedName("transmissionRiskLevel") val transmissionRiskLevel: Int
 )

--- a/android/app/src/main/java/app/covidshield/models/ExposureKey.kt
+++ b/android/app/src/main/java/app/covidshield/models/ExposureKey.kt
@@ -5,7 +5,6 @@ import com.google.gson.annotations.SerializedName
 data class ExposureKey(
     @SerializedName("keyData") val keyData: String,
     @SerializedName("rollingStartNumber") val rollingStartNumber: Int,
-    @SerializedName("rollingDuration") val rollingDuration: Int,
     @SerializedName("rollingPeriod") val rollingPeriod: Int,
     @SerializedName("transmissionRiskLevel") val transmissionRiskLevel: Int
 )

--- a/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
@@ -10,8 +10,8 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat.getSystemService
 import app.covidshield.MainActivity
 import app.covidshield.R
+import app.covidshield.extensions.launch
 import app.covidshield.extensions.parse
-import app.covidshield.extensions.rejectOnException
 import app.covidshield.extensions.toJson
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -19,7 +19,10 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.google.gson.annotations.SerializedName
-import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import java.util.*
+import kotlin.coroutines.CoroutineContext
 
 private const val CHANNEL_ID = "CovidShield"
 private const val CHANNEL_NAME = "CovidShield"
@@ -28,7 +31,7 @@ private const val CHANNEL_DESC = "CovidShield"
 /**
  * See https://developer.android.com/training/notify-user/build-notification#kotlin
  */
-class PushNotificationModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
+class PushNotificationModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), CoroutineScope {
 
     private val notificationManager = NotificationManagerCompat.from(context)
 
@@ -47,18 +50,20 @@ class PushNotificationModule(context: ReactApplicationContext) : ReactContextBas
 
     override fun getName(): String = "PushNotification"
 
+    override val coroutineContext: CoroutineContext get() = Dispatchers.Default
+
     @ReactMethod
     fun requestPermissions(config: ReadableMap, promise: Promise) {
         // Noop for Android
-        promise.resolve(Unit)
+        promise.resolve(null)
     }
 
     @ReactMethod
     fun presentLocalNotification(data: ReadableMap, promise: Promise) {
-        promise.rejectOnException {
+        promise.launch(this) {
             val config = data.toHashMap().toJson().parse(PushNotificationConfig::class.java)
             showNotification(config)
-            promise.resolve(Unit)
+            promise.resolve(null)
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-native-snap-carousel": "^3.9.0",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.0",
+    "react-native-zip-archive": "^5.0.2",
     "reanimated-bottom-sheet": "^1.0.0-alpha.20",
     "tweetnacl": "^1.0.3",
     "yarn": "^1.22.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import Reactotron from 'reactotron-react-native';
 import {NativeModules, StatusBar} from 'react-native';
 import SplashScreen from 'react-native-splash-screen';
 import {TestMode} from 'testMode';
-import {TEST_MODE, SUBMIT_URL, RETRIEVE_URL, HMAC_KEY} from 'env';
+import {TEST_MODE, SUBMIT_URL, RETRIEVE_URL, HMAC_KEY, REGION} from 'env';
 import {ExposureNotificationServiceProvider} from 'services/ExposureNotificationService';
 import {BackendService} from 'services/BackendService';
 import {SharedTranslations} from 'locale';
@@ -46,7 +46,7 @@ const App = () => {
     [locale],
   );
 
-  const backendService = useMemo(() => new BackendService(RETRIEVE_URL, SUBMIT_URL, HMAC_KEY), []);
+  const backendService = useMemo(() => new BackendService(RETRIEVE_URL, SUBMIT_URL, HMAC_KEY, REGION), []);
 
   return (
     <I18nContext.Provider value={i18nManager}>

--- a/src/bridge/ExposureNotification.ts
+++ b/src/bridge/ExposureNotification.ts
@@ -29,8 +29,7 @@ export enum Status {
 export interface TemporaryExposureKey {
   keyData: string;
   rollingStartNumber: number;
-  rollingDuration?: number;
-  rollingPeriod?: number;
+  rollingPeriod: number;
   transmissionRiskLevel: RiskLevel;
 }
 

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -16,6 +16,8 @@ export const RETRIEVE_URL = Config.RETRIEVE_URL;
 
 export const HMAC_KEY = Config.HMAC_KEY;
 
+export const REGION = parseInt(Config.REGION, 10);
+
 export const TEST_MODE = Config.TEST_MODE === 'true' || false;
 
 export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import 'react-native-gesture-handler';
 import AsyncStorage from '@react-native-community/async-storage';
 import SecureStorage from 'react-native-sensitive-info';
 import ExposureNotification from 'bridge/ExposureNotification';
-import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL} from 'env';
+import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL, REGION} from 'env';
 import {AppRegistry, YellowBox} from 'react-native';
 import {BackendService} from 'services/BackendService';
 import {BackgroundScheduler} from 'services/BackgroundSchedulerService';
@@ -20,7 +20,7 @@ import App from './App';
 AppRegistry.registerComponent(appName, () => App);
 
 BackgroundScheduler.registerAndroidHeadlessPeriodicTask(async () => {
-  const backendService = new BackendService(RETRIEVE_URL, SUBMIT_URL, HMAC_KEY);
+  const backendService = new BackendService(RETRIEVE_URL, SUBMIT_URL, HMAC_KEY, REGION);
   const i18n = await getBackgroundI18n();
   const exposureNotificationService = new ExposureNotificationService(
     backendService,

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -14,18 +14,19 @@ export class BackendService implements BackendInterface {
   retrieveUrl: string;
   submitUrl: string;
   hmacKey: string;
+  region: number;
 
-  constructor(retrieveUrl: string, submitUrl: string, hmacKey: string) {
+  constructor(retrieveUrl: string, submitUrl: string, hmacKey: string, region: number) {
     this.retrieveUrl = retrieveUrl;
     this.submitUrl = submitUrl;
     this.hmacKey = hmacKey;
+    this.region = region;
   }
 
   async retrieveDiagnosisKeys(period: number) {
-    const message = `${period}:${Math.floor(new Date().getTime() / 1000 / 3600)}`;
+    const message = `${this.region}:${period}:${Math.floor(new Date().getTime() / 1000 / 3600)}`;
     const hmac = hmac256(message, encHex.parse(this.hmacKey)).toString(encHex);
-
-    return downloadDiagnosisKeysFile(`${this.retrieveUrl}/retrieve/${period}/${hmac}`);
+    return downloadDiagnosisKeysFile(`${this.retrieveUrl}/retrieve/${this.region}/${period}/${hmac}`);
   }
 
   async getExposureConfiguration() {
@@ -60,15 +61,14 @@ export class BackendService implements BackendInterface {
     const upload = covidshield.Upload.create({
       timestamp: {seconds: Math.floor(new Date().getTime() / 1000)},
       keys: exposureKeys.map(key =>
-        covidshield.TemporaryExposureKey.create({
+        covidshield.Key.create({
           keyData: Buffer.from(key.keyData, 'base64'),
-          rollingStartIntervalNumber: key.rollingStartNumber,
           transmissionRiskLevel: key.transmissionRiskLevel,
+          rollingStartNumber: key.rollingStartNumber,
           rollingPeriod: key.rollingPeriod,
         }),
       ),
     });
-    console.log({upload: JSON.stringify(upload)});
 
     const serializedUpload = covidshield.Upload.encode(upload).finish();
 

--- a/src/services/BackendService/covidshield/covidshield.d.ts
+++ b/src/services/BackendService/covidshield/covidshield.d.ts
@@ -419,7 +419,7 @@ export namespace covidshield {
             INVALID_TIMESTAMP = 8,
             INVALID_ROLLING_PERIOD = 10,
             INVALID_KEY_DATA = 11,
-            INVALID_ROLLING_START_INTERVAL_NUMBER = 12,
+            INVALID_ROLLING_START_NUMBER = 12,
             INVALID_TRANSMISSION_RISK_LEVEL = 13
         }
     }
@@ -431,7 +431,7 @@ export namespace covidshield {
         timestamp: google.protobuf.ITimestamp;
 
         /** Upload keys */
-        keys?: (covidshield.ITemporaryExposureKey[]|null);
+        keys?: (covidshield.IKey[]|null);
     }
 
     /** Represents an Upload. */
@@ -447,7 +447,7 @@ export namespace covidshield {
         public timestamp: google.protobuf.ITimestamp;
 
         /** Upload keys. */
-        public keys: covidshield.ITemporaryExposureKey[];
+        public keys: covidshield.IKey[];
 
         /**
          * Creates a new Upload instance using the specified properties.
@@ -520,547 +520,319 @@ export namespace covidshield {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a TemporaryExposureKeyExport. */
-    interface ITemporaryExposureKeyExport {
+    /** Properties of a File. */
+    interface IFile {
 
-        /** TemporaryExposureKeyExport startTimestamp */
+        /** File header */
+        header?: (covidshield.IHeader|null);
+
+        /** File key */
+        key?: (covidshield.IKey[]|null);
+    }
+
+    /** Represents a File. */
+    class File implements IFile {
+
+        /**
+         * Constructs a new File.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: covidshield.IFile);
+
+        /** File header. */
+        public header?: (covidshield.IHeader|null);
+
+        /** File key. */
+        public key: covidshield.IKey[];
+
+        /**
+         * Creates a new File instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns File instance
+         */
+        public static create(properties?: covidshield.IFile): covidshield.File;
+
+        /**
+         * Encodes the specified File message. Does not implicitly {@link covidshield.File.verify|verify} messages.
+         * @param message File message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: covidshield.IFile, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified File message, length delimited. Does not implicitly {@link covidshield.File.verify|verify} messages.
+         * @param message File message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: covidshield.IFile, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a File message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns File
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.File;
+
+        /**
+         * Decodes a File message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns File
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.File;
+
+        /**
+         * Verifies a File message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a File message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns File
+         */
+        public static fromObject(object: { [k: string]: any }): covidshield.File;
+
+        /**
+         * Creates a plain object from a File message. Also converts values to other types if specified.
+         * @param message File
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: covidshield.File, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this File to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a Header. */
+    interface IHeader {
+
+        /** Header startTimestamp */
         startTimestamp?: (number|Long|null);
 
-        /** TemporaryExposureKeyExport endTimestamp */
+        /** Header endTimestamp */
         endTimestamp?: (number|Long|null);
 
-        /** TemporaryExposureKeyExport region */
+        /** Header region */
         region?: (string|null);
 
-        /** TemporaryExposureKeyExport batchNum */
+        /** Header batchNum */
         batchNum?: (number|null);
 
-        /** TemporaryExposureKeyExport batchSize */
+        /** Header batchSize */
         batchSize?: (number|null);
-
-        /** TemporaryExposureKeyExport signatureInfos */
-        signatureInfos?: (covidshield.ISignatureInfo[]|null);
-
-        /** TemporaryExposureKeyExport keys */
-        keys?: (covidshield.ITemporaryExposureKey[]|null);
     }
 
-    /** Represents a TemporaryExposureKeyExport. */
-    class TemporaryExposureKeyExport implements ITemporaryExposureKeyExport {
+    /** Represents a Header. */
+    class Header implements IHeader {
 
         /**
-         * Constructs a new TemporaryExposureKeyExport.
+         * Constructs a new Header.
          * @param [properties] Properties to set
          */
-        constructor(properties?: covidshield.ITemporaryExposureKeyExport);
+        constructor(properties?: covidshield.IHeader);
 
-        /** TemporaryExposureKeyExport startTimestamp. */
+        /** Header startTimestamp. */
         public startTimestamp: (number|Long);
 
-        /** TemporaryExposureKeyExport endTimestamp. */
+        /** Header endTimestamp. */
         public endTimestamp: (number|Long);
 
-        /** TemporaryExposureKeyExport region. */
+        /** Header region. */
         public region: string;
 
-        /** TemporaryExposureKeyExport batchNum. */
+        /** Header batchNum. */
         public batchNum: number;
 
-        /** TemporaryExposureKeyExport batchSize. */
+        /** Header batchSize. */
         public batchSize: number;
 
-        /** TemporaryExposureKeyExport signatureInfos. */
-        public signatureInfos: covidshield.ISignatureInfo[];
-
-        /** TemporaryExposureKeyExport keys. */
-        public keys: covidshield.ITemporaryExposureKey[];
-
         /**
-         * Creates a new TemporaryExposureKeyExport instance using the specified properties.
+         * Creates a new Header instance using the specified properties.
          * @param [properties] Properties to set
-         * @returns TemporaryExposureKeyExport instance
+         * @returns Header instance
          */
-        public static create(properties?: covidshield.ITemporaryExposureKeyExport): covidshield.TemporaryExposureKeyExport;
+        public static create(properties?: covidshield.IHeader): covidshield.Header;
 
         /**
-         * Encodes the specified TemporaryExposureKeyExport message. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
-         * @param message TemporaryExposureKeyExport message or plain object to encode
+         * Encodes the specified Header message. Does not implicitly {@link covidshield.Header.verify|verify} messages.
+         * @param message Header message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encode(message: covidshield.ITemporaryExposureKeyExport, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encode(message: covidshield.IHeader, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Encodes the specified TemporaryExposureKeyExport message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
-         * @param message TemporaryExposureKeyExport message or plain object to encode
+         * Encodes the specified Header message, length delimited. Does not implicitly {@link covidshield.Header.verify|verify} messages.
+         * @param message Header message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encodeDelimited(message: covidshield.ITemporaryExposureKeyExport, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encodeDelimited(message: covidshield.IHeader, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer.
+         * Decodes a Header message from the specified reader or buffer.
          * @param reader Reader or buffer to decode from
          * @param [length] Message length if known beforehand
-         * @returns TemporaryExposureKeyExport
+         * @returns Header
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TemporaryExposureKeyExport;
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.Header;
 
         /**
-         * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer, length delimited.
+         * Decodes a Header message from the specified reader or buffer, length delimited.
          * @param reader Reader or buffer to decode from
-         * @returns TemporaryExposureKeyExport
+         * @returns Header
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TemporaryExposureKeyExport;
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.Header;
 
         /**
-         * Verifies a TemporaryExposureKeyExport message.
+         * Verifies a Header message.
          * @param message Plain object to verify
          * @returns `null` if valid, otherwise the reason why it is not
          */
         public static verify(message: { [k: string]: any }): (string|null);
 
         /**
-         * Creates a TemporaryExposureKeyExport message from a plain object. Also converts values to their respective internal types.
+         * Creates a Header message from a plain object. Also converts values to their respective internal types.
          * @param object Plain object
-         * @returns TemporaryExposureKeyExport
+         * @returns Header
          */
-        public static fromObject(object: { [k: string]: any }): covidshield.TemporaryExposureKeyExport;
+        public static fromObject(object: { [k: string]: any }): covidshield.Header;
 
         /**
-         * Creates a plain object from a TemporaryExposureKeyExport message. Also converts values to other types if specified.
-         * @param message TemporaryExposureKeyExport
+         * Creates a plain object from a Header message. Also converts values to other types if specified.
+         * @param message Header
          * @param [options] Conversion options
          * @returns Plain object
          */
-        public static toObject(message: covidshield.TemporaryExposureKeyExport, options?: $protobuf.IConversionOptions): { [k: string]: any };
+        public static toObject(message: covidshield.Header, options?: $protobuf.IConversionOptions): { [k: string]: any };
 
         /**
-         * Converts this TemporaryExposureKeyExport to JSON.
+         * Converts this Header to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a SignatureInfo. */
-    interface ISignatureInfo {
+    /** Properties of a Key. */
+    interface IKey {
 
-        /** SignatureInfo appBundleId */
-        appBundleId?: (string|null);
-
-        /** SignatureInfo androidPackage */
-        androidPackage?: (string|null);
-
-        /** SignatureInfo verificationKeyVersion */
-        verificationKeyVersion?: (string|null);
-
-        /** SignatureInfo verificationKeyId */
-        verificationKeyId?: (string|null);
-
-        /** SignatureInfo signatureAlgorithm */
-        signatureAlgorithm?: (string|null);
-    }
-
-    /** Represents a SignatureInfo. */
-    class SignatureInfo implements ISignatureInfo {
-
-        /**
-         * Constructs a new SignatureInfo.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: covidshield.ISignatureInfo);
-
-        /** SignatureInfo appBundleId. */
-        public appBundleId: string;
-
-        /** SignatureInfo androidPackage. */
-        public androidPackage: string;
-
-        /** SignatureInfo verificationKeyVersion. */
-        public verificationKeyVersion: string;
-
-        /** SignatureInfo verificationKeyId. */
-        public verificationKeyId: string;
-
-        /** SignatureInfo signatureAlgorithm. */
-        public signatureAlgorithm: string;
-
-        /**
-         * Creates a new SignatureInfo instance using the specified properties.
-         * @param [properties] Properties to set
-         * @returns SignatureInfo instance
-         */
-        public static create(properties?: covidshield.ISignatureInfo): covidshield.SignatureInfo;
-
-        /**
-         * Encodes the specified SignatureInfo message. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
-         * @param message SignatureInfo message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: covidshield.ISignatureInfo, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified SignatureInfo message, length delimited. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
-         * @param message SignatureInfo message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: covidshield.ISignatureInfo, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a SignatureInfo message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns SignatureInfo
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.SignatureInfo;
-
-        /**
-         * Decodes a SignatureInfo message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns SignatureInfo
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.SignatureInfo;
-
-        /**
-         * Verifies a SignatureInfo message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a SignatureInfo message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns SignatureInfo
-         */
-        public static fromObject(object: { [k: string]: any }): covidshield.SignatureInfo;
-
-        /**
-         * Creates a plain object from a SignatureInfo message. Also converts values to other types if specified.
-         * @param message SignatureInfo
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: covidshield.SignatureInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this SignatureInfo to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of a TemporaryExposureKey. */
-    interface ITemporaryExposureKey {
-
-        /** TemporaryExposureKey keyData */
+        /** Key keyData */
         keyData?: (Uint8Array|null);
 
-        /** TemporaryExposureKey transmissionRiskLevel */
-        transmissionRiskLevel?: (number|null);
+        /** Key rollingStartNumber */
+        rollingStartNumber?: (number|null);
 
-        /** TemporaryExposureKey rollingStartIntervalNumber */
-        rollingStartIntervalNumber?: (number|null);
-
-        /** TemporaryExposureKey rollingPeriod */
+        /** Key rollingPeriod */
         rollingPeriod?: (number|null);
+
+        /** Key transmissionRiskLevel */
+        transmissionRiskLevel?: (number|null);
     }
 
-    /** Represents a TemporaryExposureKey. */
-    class TemporaryExposureKey implements ITemporaryExposureKey {
+    /** Represents a Key. */
+    class Key implements IKey {
 
         /**
-         * Constructs a new TemporaryExposureKey.
+         * Constructs a new Key.
          * @param [properties] Properties to set
          */
-        constructor(properties?: covidshield.ITemporaryExposureKey);
+        constructor(properties?: covidshield.IKey);
 
-        /** TemporaryExposureKey keyData. */
+        /** Key keyData. */
         public keyData: Uint8Array;
 
-        /** TemporaryExposureKey transmissionRiskLevel. */
-        public transmissionRiskLevel: number;
+        /** Key rollingStartNumber. */
+        public rollingStartNumber: number;
 
-        /** TemporaryExposureKey rollingStartIntervalNumber. */
-        public rollingStartIntervalNumber: number;
-
-        /** TemporaryExposureKey rollingPeriod. */
+        /** Key rollingPeriod. */
         public rollingPeriod: number;
 
+        /** Key transmissionRiskLevel. */
+        public transmissionRiskLevel: number;
+
         /**
-         * Creates a new TemporaryExposureKey instance using the specified properties.
+         * Creates a new Key instance using the specified properties.
          * @param [properties] Properties to set
-         * @returns TemporaryExposureKey instance
+         * @returns Key instance
          */
-        public static create(properties?: covidshield.ITemporaryExposureKey): covidshield.TemporaryExposureKey;
+        public static create(properties?: covidshield.IKey): covidshield.Key;
 
         /**
-         * Encodes the specified TemporaryExposureKey message. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
-         * @param message TemporaryExposureKey message or plain object to encode
+         * Encodes the specified Key message. Does not implicitly {@link covidshield.Key.verify|verify} messages.
+         * @param message Key message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encode(message: covidshield.ITemporaryExposureKey, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encode(message: covidshield.IKey, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Encodes the specified TemporaryExposureKey message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
-         * @param message TemporaryExposureKey message or plain object to encode
+         * Encodes the specified Key message, length delimited. Does not implicitly {@link covidshield.Key.verify|verify} messages.
+         * @param message Key message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encodeDelimited(message: covidshield.ITemporaryExposureKey, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encodeDelimited(message: covidshield.IKey, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Decodes a TemporaryExposureKey message from the specified reader or buffer.
+         * Decodes a Key message from the specified reader or buffer.
          * @param reader Reader or buffer to decode from
          * @param [length] Message length if known beforehand
-         * @returns TemporaryExposureKey
+         * @returns Key
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TemporaryExposureKey;
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.Key;
 
         /**
-         * Decodes a TemporaryExposureKey message from the specified reader or buffer, length delimited.
+         * Decodes a Key message from the specified reader or buffer, length delimited.
          * @param reader Reader or buffer to decode from
-         * @returns TemporaryExposureKey
+         * @returns Key
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TemporaryExposureKey;
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.Key;
 
         /**
-         * Verifies a TemporaryExposureKey message.
+         * Verifies a Key message.
          * @param message Plain object to verify
          * @returns `null` if valid, otherwise the reason why it is not
          */
         public static verify(message: { [k: string]: any }): (string|null);
 
         /**
-         * Creates a TemporaryExposureKey message from a plain object. Also converts values to their respective internal types.
+         * Creates a Key message from a plain object. Also converts values to their respective internal types.
          * @param object Plain object
-         * @returns TemporaryExposureKey
+         * @returns Key
          */
-        public static fromObject(object: { [k: string]: any }): covidshield.TemporaryExposureKey;
+        public static fromObject(object: { [k: string]: any }): covidshield.Key;
 
         /**
-         * Creates a plain object from a TemporaryExposureKey message. Also converts values to other types if specified.
-         * @param message TemporaryExposureKey
+         * Creates a plain object from a Key message. Also converts values to other types if specified.
+         * @param message Key
          * @param [options] Conversion options
          * @returns Plain object
          */
-        public static toObject(message: covidshield.TemporaryExposureKey, options?: $protobuf.IConversionOptions): { [k: string]: any };
+        public static toObject(message: covidshield.Key, options?: $protobuf.IConversionOptions): { [k: string]: any };
 
         /**
-         * Converts this TemporaryExposureKey to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of a TEKSignatureList. */
-    interface ITEKSignatureList {
-
-        /** TEKSignatureList signatures */
-        signatures?: (covidshield.ITEKSignature[]|null);
-    }
-
-    /** Represents a TEKSignatureList. */
-    class TEKSignatureList implements ITEKSignatureList {
-
-        /**
-         * Constructs a new TEKSignatureList.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: covidshield.ITEKSignatureList);
-
-        /** TEKSignatureList signatures. */
-        public signatures: covidshield.ITEKSignature[];
-
-        /**
-         * Creates a new TEKSignatureList instance using the specified properties.
-         * @param [properties] Properties to set
-         * @returns TEKSignatureList instance
-         */
-        public static create(properties?: covidshield.ITEKSignatureList): covidshield.TEKSignatureList;
-
-        /**
-         * Encodes the specified TEKSignatureList message. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
-         * @param message TEKSignatureList message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: covidshield.ITEKSignatureList, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified TEKSignatureList message, length delimited. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
-         * @param message TEKSignatureList message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: covidshield.ITEKSignatureList, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a TEKSignatureList message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns TEKSignatureList
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TEKSignatureList;
-
-        /**
-         * Decodes a TEKSignatureList message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns TEKSignatureList
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TEKSignatureList;
-
-        /**
-         * Verifies a TEKSignatureList message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a TEKSignatureList message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns TEKSignatureList
-         */
-        public static fromObject(object: { [k: string]: any }): covidshield.TEKSignatureList;
-
-        /**
-         * Creates a plain object from a TEKSignatureList message. Also converts values to other types if specified.
-         * @param message TEKSignatureList
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: covidshield.TEKSignatureList, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this TEKSignatureList to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of a TEKSignature. */
-    interface ITEKSignature {
-
-        /** TEKSignature signatureInfo */
-        signatureInfo?: (covidshield.ISignatureInfo|null);
-
-        /** TEKSignature batchNum */
-        batchNum?: (number|null);
-
-        /** TEKSignature batchSize */
-        batchSize?: (number|null);
-
-        /** TEKSignature signature */
-        signature?: (Uint8Array|null);
-    }
-
-    /** Represents a TEKSignature. */
-    class TEKSignature implements ITEKSignature {
-
-        /**
-         * Constructs a new TEKSignature.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: covidshield.ITEKSignature);
-
-        /** TEKSignature signatureInfo. */
-        public signatureInfo?: (covidshield.ISignatureInfo|null);
-
-        /** TEKSignature batchNum. */
-        public batchNum: number;
-
-        /** TEKSignature batchSize. */
-        public batchSize: number;
-
-        /** TEKSignature signature. */
-        public signature: Uint8Array;
-
-        /**
-         * Creates a new TEKSignature instance using the specified properties.
-         * @param [properties] Properties to set
-         * @returns TEKSignature instance
-         */
-        public static create(properties?: covidshield.ITEKSignature): covidshield.TEKSignature;
-
-        /**
-         * Encodes the specified TEKSignature message. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
-         * @param message TEKSignature message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: covidshield.ITEKSignature, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified TEKSignature message, length delimited. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
-         * @param message TEKSignature message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: covidshield.ITEKSignature, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a TEKSignature message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns TEKSignature
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TEKSignature;
-
-        /**
-         * Decodes a TEKSignature message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns TEKSignature
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TEKSignature;
-
-        /**
-         * Verifies a TEKSignature message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a TEKSignature message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns TEKSignature
-         */
-        public static fromObject(object: { [k: string]: any }): covidshield.TEKSignature;
-
-        /**
-         * Creates a plain object from a TEKSignature message. Also converts values to other types if specified.
-         * @param message TEKSignature
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: covidshield.TEKSignature, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this TEKSignature to JSON.
+         * Converts this Key to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };

--- a/src/services/BackendService/covidshield/covidshield.js
+++ b/src/services/BackendService/covidshield/covidshield.js
@@ -1010,7 +1010,7 @@
                 case 11:
                     message.error = 11;
                     break;
-                case "INVALID_ROLLING_START_INTERVAL_NUMBER":
+                case "INVALID_ROLLING_START_NUMBER":
                 case 12:
                     message.error = 12;
                     break;
@@ -1068,7 +1068,7 @@
              * @property {number} INVALID_TIMESTAMP=8 INVALID_TIMESTAMP value
              * @property {number} INVALID_ROLLING_PERIOD=10 INVALID_ROLLING_PERIOD value
              * @property {number} INVALID_KEY_DATA=11 INVALID_KEY_DATA value
-             * @property {number} INVALID_ROLLING_START_INTERVAL_NUMBER=12 INVALID_ROLLING_START_INTERVAL_NUMBER value
+             * @property {number} INVALID_ROLLING_START_NUMBER=12 INVALID_ROLLING_START_NUMBER value
              * @property {number} INVALID_TRANSMISSION_RISK_LEVEL=13 INVALID_TRANSMISSION_RISK_LEVEL value
              */
             EncryptedUploadResponse.ErrorCode = (function() {
@@ -1084,7 +1084,7 @@
                 values[valuesById[8] = "INVALID_TIMESTAMP"] = 8;
                 values[valuesById[10] = "INVALID_ROLLING_PERIOD"] = 10;
                 values[valuesById[11] = "INVALID_KEY_DATA"] = 11;
-                values[valuesById[12] = "INVALID_ROLLING_START_INTERVAL_NUMBER"] = 12;
+                values[valuesById[12] = "INVALID_ROLLING_START_NUMBER"] = 12;
                 values[valuesById[13] = "INVALID_TRANSMISSION_RISK_LEVEL"] = 13;
                 return values;
             })();
@@ -1099,7 +1099,7 @@
              * @memberof covidshield
              * @interface IUpload
              * @property {google.protobuf.ITimestamp} timestamp Upload timestamp
-             * @property {Array.<covidshield.ITemporaryExposureKey>|null} [keys] Upload keys
+             * @property {Array.<covidshield.IKey>|null} [keys] Upload keys
              */
     
             /**
@@ -1128,7 +1128,7 @@
     
             /**
              * Upload keys.
-             * @member {Array.<covidshield.ITemporaryExposureKey>} keys
+             * @member {Array.<covidshield.IKey>} keys
              * @memberof covidshield.Upload
              * @instance
              */
@@ -1161,7 +1161,7 @@
                 $root.google.protobuf.Timestamp.encode(message.timestamp, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
                 if (message.keys != null && message.keys.length)
                     for (var i = 0; i < message.keys.length; ++i)
-                        $root.covidshield.TemporaryExposureKey.encode(message.keys[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.covidshield.Key.encode(message.keys[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 return writer;
             };
     
@@ -1202,7 +1202,7 @@
                     case 2:
                         if (!(message.keys && message.keys.length))
                             message.keys = [];
-                        message.keys.push($root.covidshield.TemporaryExposureKey.decode(reader, reader.uint32()));
+                        message.keys.push($root.covidshield.Key.decode(reader, reader.uint32()));
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -1250,7 +1250,7 @@
                     if (!Array.isArray(message.keys))
                         return "keys: array expected";
                     for (var i = 0; i < message.keys.length; ++i) {
-                        var error = $root.covidshield.TemporaryExposureKey.verify(message.keys[i]);
+                        var error = $root.covidshield.Key.verify(message.keys[i]);
                         if (error)
                             return "keys." + error;
                     }
@@ -1282,7 +1282,7 @@
                     for (var i = 0; i < object.keys.length; ++i) {
                         if (typeof object.keys[i] !== "object")
                             throw TypeError(".covidshield.Upload.keys: object expected");
-                        message.keys[i] = $root.covidshield.TemporaryExposureKey.fromObject(object.keys[i]);
+                        message.keys[i] = $root.covidshield.Key.fromObject(object.keys[i]);
                     }
                 }
                 return message;
@@ -1310,7 +1310,7 @@
                 if (message.keys && message.keys.length) {
                     object.keys = [];
                     for (var j = 0; j < message.keys.length; ++j)
-                        object.keys[j] = $root.covidshield.TemporaryExposureKey.toObject(message.keys[j], options);
+                        object.keys[j] = $root.covidshield.Key.toObject(message.keys[j], options);
                 }
                 return object;
             };
@@ -1329,32 +1329,26 @@
             return Upload;
         })();
     
-        covidshield.TemporaryExposureKeyExport = (function() {
+        covidshield.File = (function() {
     
             /**
-             * Properties of a TemporaryExposureKeyExport.
+             * Properties of a File.
              * @memberof covidshield
-             * @interface ITemporaryExposureKeyExport
-             * @property {number|Long|null} [startTimestamp] TemporaryExposureKeyExport startTimestamp
-             * @property {number|Long|null} [endTimestamp] TemporaryExposureKeyExport endTimestamp
-             * @property {string|null} [region] TemporaryExposureKeyExport region
-             * @property {number|null} [batchNum] TemporaryExposureKeyExport batchNum
-             * @property {number|null} [batchSize] TemporaryExposureKeyExport batchSize
-             * @property {Array.<covidshield.ISignatureInfo>|null} [signatureInfos] TemporaryExposureKeyExport signatureInfos
-             * @property {Array.<covidshield.ITemporaryExposureKey>|null} [keys] TemporaryExposureKeyExport keys
+             * @interface IFile
+             * @property {covidshield.IHeader|null} [header] File header
+             * @property {Array.<covidshield.IKey>|null} [key] File key
              */
     
             /**
-             * Constructs a new TemporaryExposureKeyExport.
+             * Constructs a new File.
              * @memberof covidshield
-             * @classdesc Represents a TemporaryExposureKeyExport.
-             * @implements ITemporaryExposureKeyExport
+             * @classdesc Represents a File.
+             * @implements IFile
              * @constructor
-             * @param {covidshield.ITemporaryExposureKeyExport=} [properties] Properties to set
+             * @param {covidshield.IFile=} [properties] Properties to set
              */
-            function TemporaryExposureKeyExport(properties) {
-                this.signatureInfos = [];
-                this.keys = [];
+            function File(properties) {
+                this.key = [];
                 if (properties)
                     for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                         if (properties[keys[i]] != null)
@@ -1362,159 +1356,91 @@
             }
     
             /**
-             * TemporaryExposureKeyExport startTimestamp.
-             * @member {number|Long} startTimestamp
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * File header.
+             * @member {covidshield.IHeader|null|undefined} header
+             * @memberof covidshield.File
              * @instance
              */
-            TemporaryExposureKeyExport.prototype.startTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+            File.prototype.header = null;
     
             /**
-             * TemporaryExposureKeyExport endTimestamp.
-             * @member {number|Long} endTimestamp
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * File key.
+             * @member {Array.<covidshield.IKey>} key
+             * @memberof covidshield.File
              * @instance
              */
-            TemporaryExposureKeyExport.prototype.endTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+            File.prototype.key = $util.emptyArray;
     
             /**
-             * TemporaryExposureKeyExport region.
-             * @member {string} region
-             * @memberof covidshield.TemporaryExposureKeyExport
-             * @instance
-             */
-            TemporaryExposureKeyExport.prototype.region = "";
-    
-            /**
-             * TemporaryExposureKeyExport batchNum.
-             * @member {number} batchNum
-             * @memberof covidshield.TemporaryExposureKeyExport
-             * @instance
-             */
-            TemporaryExposureKeyExport.prototype.batchNum = 0;
-    
-            /**
-             * TemporaryExposureKeyExport batchSize.
-             * @member {number} batchSize
-             * @memberof covidshield.TemporaryExposureKeyExport
-             * @instance
-             */
-            TemporaryExposureKeyExport.prototype.batchSize = 0;
-    
-            /**
-             * TemporaryExposureKeyExport signatureInfos.
-             * @member {Array.<covidshield.ISignatureInfo>} signatureInfos
-             * @memberof covidshield.TemporaryExposureKeyExport
-             * @instance
-             */
-            TemporaryExposureKeyExport.prototype.signatureInfos = $util.emptyArray;
-    
-            /**
-             * TemporaryExposureKeyExport keys.
-             * @member {Array.<covidshield.ITemporaryExposureKey>} keys
-             * @memberof covidshield.TemporaryExposureKeyExport
-             * @instance
-             */
-            TemporaryExposureKeyExport.prototype.keys = $util.emptyArray;
-    
-            /**
-             * Creates a new TemporaryExposureKeyExport instance using the specified properties.
+             * Creates a new File instance using the specified properties.
              * @function create
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.File
              * @static
-             * @param {covidshield.ITemporaryExposureKeyExport=} [properties] Properties to set
-             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport instance
+             * @param {covidshield.IFile=} [properties] Properties to set
+             * @returns {covidshield.File} File instance
              */
-            TemporaryExposureKeyExport.create = function create(properties) {
-                return new TemporaryExposureKeyExport(properties);
+            File.create = function create(properties) {
+                return new File(properties);
             };
     
             /**
-             * Encodes the specified TemporaryExposureKeyExport message. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
+             * Encodes the specified File message. Does not implicitly {@link covidshield.File.verify|verify} messages.
              * @function encode
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.File
              * @static
-             * @param {covidshield.ITemporaryExposureKeyExport} message TemporaryExposureKeyExport message or plain object to encode
+             * @param {covidshield.IFile} message File message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TemporaryExposureKeyExport.encode = function encode(message, writer) {
+            File.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.startTimestamp != null && Object.hasOwnProperty.call(message, "startTimestamp"))
-                    writer.uint32(/* id 1, wireType 1 =*/9).fixed64(message.startTimestamp);
-                if (message.endTimestamp != null && Object.hasOwnProperty.call(message, "endTimestamp"))
-                    writer.uint32(/* id 2, wireType 1 =*/17).fixed64(message.endTimestamp);
-                if (message.region != null && Object.hasOwnProperty.call(message, "region"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.region);
-                if (message.batchNum != null && Object.hasOwnProperty.call(message, "batchNum"))
-                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.batchNum);
-                if (message.batchSize != null && Object.hasOwnProperty.call(message, "batchSize"))
-                    writer.uint32(/* id 5, wireType 0 =*/40).int32(message.batchSize);
-                if (message.signatureInfos != null && message.signatureInfos.length)
-                    for (var i = 0; i < message.signatureInfos.length; ++i)
-                        $root.covidshield.SignatureInfo.encode(message.signatureInfos[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-                if (message.keys != null && message.keys.length)
-                    for (var i = 0; i < message.keys.length; ++i)
-                        $root.covidshield.TemporaryExposureKey.encode(message.keys[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                if (message.header != null && Object.hasOwnProperty.call(message, "header"))
+                    $root.covidshield.Header.encode(message.header, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.key != null && message.key.length)
+                    for (var i = 0; i < message.key.length; ++i)
+                        $root.covidshield.Key.encode(message.key[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 return writer;
             };
     
             /**
-             * Encodes the specified TemporaryExposureKeyExport message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
+             * Encodes the specified File message, length delimited. Does not implicitly {@link covidshield.File.verify|verify} messages.
              * @function encodeDelimited
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.File
              * @static
-             * @param {covidshield.ITemporaryExposureKeyExport} message TemporaryExposureKeyExport message or plain object to encode
+             * @param {covidshield.IFile} message File message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TemporaryExposureKeyExport.encodeDelimited = function encodeDelimited(message, writer) {
+            File.encodeDelimited = function encodeDelimited(message, writer) {
                 return this.encode(message, writer).ldelim();
             };
     
             /**
-             * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer.
+             * Decodes a File message from the specified reader or buffer.
              * @function decode
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.File
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
              * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport
+             * @returns {covidshield.File} File
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            TemporaryExposureKeyExport.decode = function decode(reader, length) {
+            File.decode = function decode(reader, length) {
                 if (!(reader instanceof $Reader))
                     reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TemporaryExposureKeyExport();
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.File();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     case 1:
-                        message.startTimestamp = reader.fixed64();
+                        message.header = $root.covidshield.Header.decode(reader, reader.uint32());
                         break;
                     case 2:
-                        message.endTimestamp = reader.fixed64();
-                        break;
-                    case 3:
-                        message.region = reader.string();
-                        break;
-                    case 4:
-                        message.batchNum = reader.int32();
-                        break;
-                    case 5:
-                        message.batchSize = reader.int32();
-                        break;
-                    case 6:
-                        if (!(message.signatureInfos && message.signatureInfos.length))
-                            message.signatureInfos = [];
-                        message.signatureInfos.push($root.covidshield.SignatureInfo.decode(reader, reader.uint32()));
-                        break;
-                    case 7:
-                        if (!(message.keys && message.keys.length))
-                            message.keys = [];
-                        message.keys.push($root.covidshield.TemporaryExposureKey.decode(reader, reader.uint32()));
+                        if (!(message.key && message.key.length))
+                            message.key = [];
+                        message.key.push($root.covidshield.Key.decode(reader, reader.uint32()));
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -1525,30 +1451,304 @@
             };
     
             /**
-             * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer, length delimited.
+             * Decodes a File message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.File
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport
+             * @returns {covidshield.File} File
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            TemporaryExposureKeyExport.decodeDelimited = function decodeDelimited(reader) {
+            File.decodeDelimited = function decodeDelimited(reader) {
                 if (!(reader instanceof $Reader))
                     reader = new $Reader(reader);
                 return this.decode(reader, reader.uint32());
             };
     
             /**
-             * Verifies a TemporaryExposureKeyExport message.
+             * Verifies a File message.
              * @function verify
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.File
              * @static
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-            TemporaryExposureKeyExport.verify = function verify(message) {
+            File.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.header != null && message.hasOwnProperty("header")) {
+                    var error = $root.covidshield.Header.verify(message.header);
+                    if (error)
+                        return "header." + error;
+                }
+                if (message.key != null && message.hasOwnProperty("key")) {
+                    if (!Array.isArray(message.key))
+                        return "key: array expected";
+                    for (var i = 0; i < message.key.length; ++i) {
+                        var error = $root.covidshield.Key.verify(message.key[i]);
+                        if (error)
+                            return "key." + error;
+                    }
+                }
+                return null;
+            };
+    
+            /**
+             * Creates a File message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof covidshield.File
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {covidshield.File} File
+             */
+            File.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.File)
+                    return object;
+                var message = new $root.covidshield.File();
+                if (object.header != null) {
+                    if (typeof object.header !== "object")
+                        throw TypeError(".covidshield.File.header: object expected");
+                    message.header = $root.covidshield.Header.fromObject(object.header);
+                }
+                if (object.key) {
+                    if (!Array.isArray(object.key))
+                        throw TypeError(".covidshield.File.key: array expected");
+                    message.key = [];
+                    for (var i = 0; i < object.key.length; ++i) {
+                        if (typeof object.key[i] !== "object")
+                            throw TypeError(".covidshield.File.key: object expected");
+                        message.key[i] = $root.covidshield.Key.fromObject(object.key[i]);
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a File message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof covidshield.File
+             * @static
+             * @param {covidshield.File} message File
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            File.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.key = [];
+                if (options.defaults)
+                    object.header = null;
+                if (message.header != null && message.hasOwnProperty("header"))
+                    object.header = $root.covidshield.Header.toObject(message.header, options);
+                if (message.key && message.key.length) {
+                    object.key = [];
+                    for (var j = 0; j < message.key.length; ++j)
+                        object.key[j] = $root.covidshield.Key.toObject(message.key[j], options);
+                }
+                return object;
+            };
+    
+            /**
+             * Converts this File to JSON.
+             * @function toJSON
+             * @memberof covidshield.File
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            File.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return File;
+        })();
+    
+        covidshield.Header = (function() {
+    
+            /**
+             * Properties of a Header.
+             * @memberof covidshield
+             * @interface IHeader
+             * @property {number|Long|null} [startTimestamp] Header startTimestamp
+             * @property {number|Long|null} [endTimestamp] Header endTimestamp
+             * @property {string|null} [region] Header region
+             * @property {number|null} [batchNum] Header batchNum
+             * @property {number|null} [batchSize] Header batchSize
+             */
+    
+            /**
+             * Constructs a new Header.
+             * @memberof covidshield
+             * @classdesc Represents a Header.
+             * @implements IHeader
+             * @constructor
+             * @param {covidshield.IHeader=} [properties] Properties to set
+             */
+            function Header(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * Header startTimestamp.
+             * @member {number|Long} startTimestamp
+             * @memberof covidshield.Header
+             * @instance
+             */
+            Header.prototype.startTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+    
+            /**
+             * Header endTimestamp.
+             * @member {number|Long} endTimestamp
+             * @memberof covidshield.Header
+             * @instance
+             */
+            Header.prototype.endTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+    
+            /**
+             * Header region.
+             * @member {string} region
+             * @memberof covidshield.Header
+             * @instance
+             */
+            Header.prototype.region = "";
+    
+            /**
+             * Header batchNum.
+             * @member {number} batchNum
+             * @memberof covidshield.Header
+             * @instance
+             */
+            Header.prototype.batchNum = 0;
+    
+            /**
+             * Header batchSize.
+             * @member {number} batchSize
+             * @memberof covidshield.Header
+             * @instance
+             */
+            Header.prototype.batchSize = 0;
+    
+            /**
+             * Creates a new Header instance using the specified properties.
+             * @function create
+             * @memberof covidshield.Header
+             * @static
+             * @param {covidshield.IHeader=} [properties] Properties to set
+             * @returns {covidshield.Header} Header instance
+             */
+            Header.create = function create(properties) {
+                return new Header(properties);
+            };
+    
+            /**
+             * Encodes the specified Header message. Does not implicitly {@link covidshield.Header.verify|verify} messages.
+             * @function encode
+             * @memberof covidshield.Header
+             * @static
+             * @param {covidshield.IHeader} message Header message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Header.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.startTimestamp != null && Object.hasOwnProperty.call(message, "startTimestamp"))
+                    writer.uint32(/* id 1, wireType 0 =*/8).int64(message.startTimestamp);
+                if (message.endTimestamp != null && Object.hasOwnProperty.call(message, "endTimestamp"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int64(message.endTimestamp);
+                if (message.region != null && Object.hasOwnProperty.call(message, "region"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.region);
+                if (message.batchNum != null && Object.hasOwnProperty.call(message, "batchNum"))
+                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.batchNum);
+                if (message.batchSize != null && Object.hasOwnProperty.call(message, "batchSize"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).int32(message.batchSize);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified Header message, length delimited. Does not implicitly {@link covidshield.Header.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof covidshield.Header
+             * @static
+             * @param {covidshield.IHeader} message Header message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Header.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a Header message from the specified reader or buffer.
+             * @function decode
+             * @memberof covidshield.Header
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {covidshield.Header} Header
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Header.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.Header();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.startTimestamp = reader.int64();
+                        break;
+                    case 2:
+                        message.endTimestamp = reader.int64();
+                        break;
+                    case 3:
+                        message.region = reader.string();
+                        break;
+                    case 4:
+                        message.batchNum = reader.int32();
+                        break;
+                    case 5:
+                        message.batchSize = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a Header message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof covidshield.Header
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {covidshield.Header} Header
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Header.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a Header message.
+             * @function verify
+             * @memberof covidshield.Header
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            Header.verify = function verify(message) {
                 if (typeof message !== "object" || message === null)
                     return "object expected";
                 if (message.startTimestamp != null && message.hasOwnProperty("startTimestamp"))
@@ -1566,39 +1766,21 @@
                 if (message.batchSize != null && message.hasOwnProperty("batchSize"))
                     if (!$util.isInteger(message.batchSize))
                         return "batchSize: integer expected";
-                if (message.signatureInfos != null && message.hasOwnProperty("signatureInfos")) {
-                    if (!Array.isArray(message.signatureInfos))
-                        return "signatureInfos: array expected";
-                    for (var i = 0; i < message.signatureInfos.length; ++i) {
-                        var error = $root.covidshield.SignatureInfo.verify(message.signatureInfos[i]);
-                        if (error)
-                            return "signatureInfos." + error;
-                    }
-                }
-                if (message.keys != null && message.hasOwnProperty("keys")) {
-                    if (!Array.isArray(message.keys))
-                        return "keys: array expected";
-                    for (var i = 0; i < message.keys.length; ++i) {
-                        var error = $root.covidshield.TemporaryExposureKey.verify(message.keys[i]);
-                        if (error)
-                            return "keys." + error;
-                    }
-                }
                 return null;
             };
     
             /**
-             * Creates a TemporaryExposureKeyExport message from a plain object. Also converts values to their respective internal types.
+             * Creates a Header message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.Header
              * @static
              * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport
+             * @returns {covidshield.Header} Header
              */
-            TemporaryExposureKeyExport.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.TemporaryExposureKeyExport)
+            Header.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.Header)
                     return object;
-                var message = new $root.covidshield.TemporaryExposureKeyExport();
+                var message = new $root.covidshield.Header();
                 if (object.startTimestamp != null)
                     if ($util.Long)
                         (message.startTimestamp = $util.Long.fromValue(object.startTimestamp)).unsigned = false;
@@ -1623,46 +1805,22 @@
                     message.batchNum = object.batchNum | 0;
                 if (object.batchSize != null)
                     message.batchSize = object.batchSize | 0;
-                if (object.signatureInfos) {
-                    if (!Array.isArray(object.signatureInfos))
-                        throw TypeError(".covidshield.TemporaryExposureKeyExport.signatureInfos: array expected");
-                    message.signatureInfos = [];
-                    for (var i = 0; i < object.signatureInfos.length; ++i) {
-                        if (typeof object.signatureInfos[i] !== "object")
-                            throw TypeError(".covidshield.TemporaryExposureKeyExport.signatureInfos: object expected");
-                        message.signatureInfos[i] = $root.covidshield.SignatureInfo.fromObject(object.signatureInfos[i]);
-                    }
-                }
-                if (object.keys) {
-                    if (!Array.isArray(object.keys))
-                        throw TypeError(".covidshield.TemporaryExposureKeyExport.keys: array expected");
-                    message.keys = [];
-                    for (var i = 0; i < object.keys.length; ++i) {
-                        if (typeof object.keys[i] !== "object")
-                            throw TypeError(".covidshield.TemporaryExposureKeyExport.keys: object expected");
-                        message.keys[i] = $root.covidshield.TemporaryExposureKey.fromObject(object.keys[i]);
-                    }
-                }
                 return message;
             };
     
             /**
-             * Creates a plain object from a TemporaryExposureKeyExport message. Also converts values to other types if specified.
+             * Creates a plain object from a Header message. Also converts values to other types if specified.
              * @function toObject
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.Header
              * @static
-             * @param {covidshield.TemporaryExposureKeyExport} message TemporaryExposureKeyExport
+             * @param {covidshield.Header} message Header
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TemporaryExposureKeyExport.toObject = function toObject(message, options) {
+            Header.toObject = function toObject(message, options) {
                 if (!options)
                     options = {};
                 var object = {};
-                if (options.arrays || options.defaults) {
-                    object.signatureInfos = [];
-                    object.keys = [];
-                }
                 if (options.defaults) {
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, false);
@@ -1694,55 +1852,44 @@
                     object.batchNum = message.batchNum;
                 if (message.batchSize != null && message.hasOwnProperty("batchSize"))
                     object.batchSize = message.batchSize;
-                if (message.signatureInfos && message.signatureInfos.length) {
-                    object.signatureInfos = [];
-                    for (var j = 0; j < message.signatureInfos.length; ++j)
-                        object.signatureInfos[j] = $root.covidshield.SignatureInfo.toObject(message.signatureInfos[j], options);
-                }
-                if (message.keys && message.keys.length) {
-                    object.keys = [];
-                    for (var j = 0; j < message.keys.length; ++j)
-                        object.keys[j] = $root.covidshield.TemporaryExposureKey.toObject(message.keys[j], options);
-                }
                 return object;
             };
     
             /**
-             * Converts this TemporaryExposureKeyExport to JSON.
+             * Converts this Header to JSON.
              * @function toJSON
-             * @memberof covidshield.TemporaryExposureKeyExport
+             * @memberof covidshield.Header
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-            TemporaryExposureKeyExport.prototype.toJSON = function toJSON() {
+            Header.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
     
-            return TemporaryExposureKeyExport;
+            return Header;
         })();
     
-        covidshield.SignatureInfo = (function() {
+        covidshield.Key = (function() {
     
             /**
-             * Properties of a SignatureInfo.
+             * Properties of a Key.
              * @memberof covidshield
-             * @interface ISignatureInfo
-             * @property {string|null} [appBundleId] SignatureInfo appBundleId
-             * @property {string|null} [androidPackage] SignatureInfo androidPackage
-             * @property {string|null} [verificationKeyVersion] SignatureInfo verificationKeyVersion
-             * @property {string|null} [verificationKeyId] SignatureInfo verificationKeyId
-             * @property {string|null} [signatureAlgorithm] SignatureInfo signatureAlgorithm
+             * @interface IKey
+             * @property {Uint8Array|null} [keyData] Key keyData
+             * @property {number|null} [rollingStartNumber] Key rollingStartNumber
+             * @property {number|null} [rollingPeriod] Key rollingPeriod
+             * @property {number|null} [transmissionRiskLevel] Key transmissionRiskLevel
              */
     
             /**
-             * Constructs a new SignatureInfo.
+             * Constructs a new Key.
              * @memberof covidshield
-             * @classdesc Represents a SignatureInfo.
-             * @implements ISignatureInfo
+             * @classdesc Represents a Key.
+             * @implements IKey
              * @constructor
-             * @param {covidshield.ISignatureInfo=} [properties] Properties to set
+             * @param {covidshield.IKey=} [properties] Properties to set
              */
-            function SignatureInfo(properties) {
+            function Key(properties) {
                 if (properties)
                     for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                         if (properties[keys[i]] != null)
@@ -1750,375 +1897,100 @@
             }
     
             /**
-             * SignatureInfo appBundleId.
-             * @member {string} appBundleId
-             * @memberof covidshield.SignatureInfo
-             * @instance
-             */
-            SignatureInfo.prototype.appBundleId = "";
-    
-            /**
-             * SignatureInfo androidPackage.
-             * @member {string} androidPackage
-             * @memberof covidshield.SignatureInfo
-             * @instance
-             */
-            SignatureInfo.prototype.androidPackage = "";
-    
-            /**
-             * SignatureInfo verificationKeyVersion.
-             * @member {string} verificationKeyVersion
-             * @memberof covidshield.SignatureInfo
-             * @instance
-             */
-            SignatureInfo.prototype.verificationKeyVersion = "";
-    
-            /**
-             * SignatureInfo verificationKeyId.
-             * @member {string} verificationKeyId
-             * @memberof covidshield.SignatureInfo
-             * @instance
-             */
-            SignatureInfo.prototype.verificationKeyId = "";
-    
-            /**
-             * SignatureInfo signatureAlgorithm.
-             * @member {string} signatureAlgorithm
-             * @memberof covidshield.SignatureInfo
-             * @instance
-             */
-            SignatureInfo.prototype.signatureAlgorithm = "";
-    
-            /**
-             * Creates a new SignatureInfo instance using the specified properties.
-             * @function create
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {covidshield.ISignatureInfo=} [properties] Properties to set
-             * @returns {covidshield.SignatureInfo} SignatureInfo instance
-             */
-            SignatureInfo.create = function create(properties) {
-                return new SignatureInfo(properties);
-            };
-    
-            /**
-             * Encodes the specified SignatureInfo message. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
-             * @function encode
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {covidshield.ISignatureInfo} message SignatureInfo message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            SignatureInfo.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.appBundleId != null && Object.hasOwnProperty.call(message, "appBundleId"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.appBundleId);
-                if (message.androidPackage != null && Object.hasOwnProperty.call(message, "androidPackage"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.androidPackage);
-                if (message.verificationKeyVersion != null && Object.hasOwnProperty.call(message, "verificationKeyVersion"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.verificationKeyVersion);
-                if (message.verificationKeyId != null && Object.hasOwnProperty.call(message, "verificationKeyId"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.verificationKeyId);
-                if (message.signatureAlgorithm != null && Object.hasOwnProperty.call(message, "signatureAlgorithm"))
-                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.signatureAlgorithm);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified SignatureInfo message, length delimited. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {covidshield.ISignatureInfo} message SignatureInfo message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            SignatureInfo.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a SignatureInfo message from the specified reader or buffer.
-             * @function decode
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.SignatureInfo} SignatureInfo
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            SignatureInfo.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.SignatureInfo();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.appBundleId = reader.string();
-                        break;
-                    case 2:
-                        message.androidPackage = reader.string();
-                        break;
-                    case 3:
-                        message.verificationKeyVersion = reader.string();
-                        break;
-                    case 4:
-                        message.verificationKeyId = reader.string();
-                        break;
-                    case 5:
-                        message.signatureAlgorithm = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a SignatureInfo message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.SignatureInfo} SignatureInfo
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            SignatureInfo.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a SignatureInfo message.
-             * @function verify
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            SignatureInfo.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.appBundleId != null && message.hasOwnProperty("appBundleId"))
-                    if (!$util.isString(message.appBundleId))
-                        return "appBundleId: string expected";
-                if (message.androidPackage != null && message.hasOwnProperty("androidPackage"))
-                    if (!$util.isString(message.androidPackage))
-                        return "androidPackage: string expected";
-                if (message.verificationKeyVersion != null && message.hasOwnProperty("verificationKeyVersion"))
-                    if (!$util.isString(message.verificationKeyVersion))
-                        return "verificationKeyVersion: string expected";
-                if (message.verificationKeyId != null && message.hasOwnProperty("verificationKeyId"))
-                    if (!$util.isString(message.verificationKeyId))
-                        return "verificationKeyId: string expected";
-                if (message.signatureAlgorithm != null && message.hasOwnProperty("signatureAlgorithm"))
-                    if (!$util.isString(message.signatureAlgorithm))
-                        return "signatureAlgorithm: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a SignatureInfo message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.SignatureInfo} SignatureInfo
-             */
-            SignatureInfo.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.SignatureInfo)
-                    return object;
-                var message = new $root.covidshield.SignatureInfo();
-                if (object.appBundleId != null)
-                    message.appBundleId = String(object.appBundleId);
-                if (object.androidPackage != null)
-                    message.androidPackage = String(object.androidPackage);
-                if (object.verificationKeyVersion != null)
-                    message.verificationKeyVersion = String(object.verificationKeyVersion);
-                if (object.verificationKeyId != null)
-                    message.verificationKeyId = String(object.verificationKeyId);
-                if (object.signatureAlgorithm != null)
-                    message.signatureAlgorithm = String(object.signatureAlgorithm);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a SignatureInfo message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof covidshield.SignatureInfo
-             * @static
-             * @param {covidshield.SignatureInfo} message SignatureInfo
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            SignatureInfo.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.appBundleId = "";
-                    object.androidPackage = "";
-                    object.verificationKeyVersion = "";
-                    object.verificationKeyId = "";
-                    object.signatureAlgorithm = "";
-                }
-                if (message.appBundleId != null && message.hasOwnProperty("appBundleId"))
-                    object.appBundleId = message.appBundleId;
-                if (message.androidPackage != null && message.hasOwnProperty("androidPackage"))
-                    object.androidPackage = message.androidPackage;
-                if (message.verificationKeyVersion != null && message.hasOwnProperty("verificationKeyVersion"))
-                    object.verificationKeyVersion = message.verificationKeyVersion;
-                if (message.verificationKeyId != null && message.hasOwnProperty("verificationKeyId"))
-                    object.verificationKeyId = message.verificationKeyId;
-                if (message.signatureAlgorithm != null && message.hasOwnProperty("signatureAlgorithm"))
-                    object.signatureAlgorithm = message.signatureAlgorithm;
-                return object;
-            };
-    
-            /**
-             * Converts this SignatureInfo to JSON.
-             * @function toJSON
-             * @memberof covidshield.SignatureInfo
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            SignatureInfo.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return SignatureInfo;
-        })();
-    
-        covidshield.TemporaryExposureKey = (function() {
-    
-            /**
-             * Properties of a TemporaryExposureKey.
-             * @memberof covidshield
-             * @interface ITemporaryExposureKey
-             * @property {Uint8Array|null} [keyData] TemporaryExposureKey keyData
-             * @property {number|null} [transmissionRiskLevel] TemporaryExposureKey transmissionRiskLevel
-             * @property {number|null} [rollingStartIntervalNumber] TemporaryExposureKey rollingStartIntervalNumber
-             * @property {number|null} [rollingPeriod] TemporaryExposureKey rollingPeriod
-             */
-    
-            /**
-             * Constructs a new TemporaryExposureKey.
-             * @memberof covidshield
-             * @classdesc Represents a TemporaryExposureKey.
-             * @implements ITemporaryExposureKey
-             * @constructor
-             * @param {covidshield.ITemporaryExposureKey=} [properties] Properties to set
-             */
-            function TemporaryExposureKey(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * TemporaryExposureKey keyData.
+             * Key keyData.
              * @member {Uint8Array} keyData
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @instance
              */
-            TemporaryExposureKey.prototype.keyData = $util.newBuffer([]);
+            Key.prototype.keyData = $util.newBuffer([]);
     
             /**
-             * TemporaryExposureKey transmissionRiskLevel.
-             * @member {number} transmissionRiskLevel
-             * @memberof covidshield.TemporaryExposureKey
+             * Key rollingStartNumber.
+             * @member {number} rollingStartNumber
+             * @memberof covidshield.Key
              * @instance
              */
-            TemporaryExposureKey.prototype.transmissionRiskLevel = 0;
+            Key.prototype.rollingStartNumber = 0;
     
             /**
-             * TemporaryExposureKey rollingStartIntervalNumber.
-             * @member {number} rollingStartIntervalNumber
-             * @memberof covidshield.TemporaryExposureKey
-             * @instance
-             */
-            TemporaryExposureKey.prototype.rollingStartIntervalNumber = 0;
-    
-            /**
-             * TemporaryExposureKey rollingPeriod.
+             * Key rollingPeriod.
              * @member {number} rollingPeriod
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @instance
              */
-            TemporaryExposureKey.prototype.rollingPeriod = 144;
+            Key.prototype.rollingPeriod = 0;
     
             /**
-             * Creates a new TemporaryExposureKey instance using the specified properties.
-             * @function create
-             * @memberof covidshield.TemporaryExposureKey
-             * @static
-             * @param {covidshield.ITemporaryExposureKey=} [properties] Properties to set
-             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey instance
+             * Key transmissionRiskLevel.
+             * @member {number} transmissionRiskLevel
+             * @memberof covidshield.Key
+             * @instance
              */
-            TemporaryExposureKey.create = function create(properties) {
-                return new TemporaryExposureKey(properties);
+            Key.prototype.transmissionRiskLevel = 0;
+    
+            /**
+             * Creates a new Key instance using the specified properties.
+             * @function create
+             * @memberof covidshield.Key
+             * @static
+             * @param {covidshield.IKey=} [properties] Properties to set
+             * @returns {covidshield.Key} Key instance
+             */
+            Key.create = function create(properties) {
+                return new Key(properties);
             };
     
             /**
-             * Encodes the specified TemporaryExposureKey message. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
+             * Encodes the specified Key message. Does not implicitly {@link covidshield.Key.verify|verify} messages.
              * @function encode
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
-             * @param {covidshield.ITemporaryExposureKey} message TemporaryExposureKey message or plain object to encode
+             * @param {covidshield.IKey} message Key message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TemporaryExposureKey.encode = function encode(message, writer) {
+            Key.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
                 if (message.keyData != null && Object.hasOwnProperty.call(message, "keyData"))
                     writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.keyData);
-                if (message.transmissionRiskLevel != null && Object.hasOwnProperty.call(message, "transmissionRiskLevel"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.transmissionRiskLevel);
-                if (message.rollingStartIntervalNumber != null && Object.hasOwnProperty.call(message, "rollingStartIntervalNumber"))
-                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.rollingStartIntervalNumber);
+                if (message.rollingStartNumber != null && Object.hasOwnProperty.call(message, "rollingStartNumber"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.rollingStartNumber);
                 if (message.rollingPeriod != null && Object.hasOwnProperty.call(message, "rollingPeriod"))
-                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.rollingPeriod);
+                    writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.rollingPeriod);
+                if (message.transmissionRiskLevel != null && Object.hasOwnProperty.call(message, "transmissionRiskLevel"))
+                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.transmissionRiskLevel);
                 return writer;
             };
     
             /**
-             * Encodes the specified TemporaryExposureKey message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
+             * Encodes the specified Key message, length delimited. Does not implicitly {@link covidshield.Key.verify|verify} messages.
              * @function encodeDelimited
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
-             * @param {covidshield.ITemporaryExposureKey} message TemporaryExposureKey message or plain object to encode
+             * @param {covidshield.IKey} message Key message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TemporaryExposureKey.encodeDelimited = function encodeDelimited(message, writer) {
+            Key.encodeDelimited = function encodeDelimited(message, writer) {
                 return this.encode(message, writer).ldelim();
             };
     
             /**
-             * Decodes a TemporaryExposureKey message from the specified reader or buffer.
+             * Decodes a Key message from the specified reader or buffer.
              * @function decode
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
              * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey
+             * @returns {covidshield.Key} Key
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            TemporaryExposureKey.decode = function decode(reader, length) {
+            Key.decode = function decode(reader, length) {
                 if (!(reader instanceof $Reader))
                     reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TemporaryExposureKey();
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.Key();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
@@ -2126,13 +1998,13 @@
                         message.keyData = reader.bytes();
                         break;
                     case 2:
-                        message.transmissionRiskLevel = reader.int32();
+                        message.rollingStartNumber = reader.uint32();
                         break;
                     case 3:
-                        message.rollingStartIntervalNumber = reader.int32();
+                        message.rollingPeriod = reader.uint32();
                         break;
                     case 4:
-                        message.rollingPeriod = reader.int32();
+                        message.transmissionRiskLevel = reader.int32();
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -2143,83 +2015,83 @@
             };
     
             /**
-             * Decodes a TemporaryExposureKey message from the specified reader or buffer, length delimited.
+             * Decodes a Key message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey
+             * @returns {covidshield.Key} Key
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            TemporaryExposureKey.decodeDelimited = function decodeDelimited(reader) {
+            Key.decodeDelimited = function decodeDelimited(reader) {
                 if (!(reader instanceof $Reader))
                     reader = new $Reader(reader);
                 return this.decode(reader, reader.uint32());
             };
     
             /**
-             * Verifies a TemporaryExposureKey message.
+             * Verifies a Key message.
              * @function verify
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-            TemporaryExposureKey.verify = function verify(message) {
+            Key.verify = function verify(message) {
                 if (typeof message !== "object" || message === null)
                     return "object expected";
                 if (message.keyData != null && message.hasOwnProperty("keyData"))
                     if (!(message.keyData && typeof message.keyData.length === "number" || $util.isString(message.keyData)))
                         return "keyData: buffer expected";
-                if (message.transmissionRiskLevel != null && message.hasOwnProperty("transmissionRiskLevel"))
-                    if (!$util.isInteger(message.transmissionRiskLevel))
-                        return "transmissionRiskLevel: integer expected";
-                if (message.rollingStartIntervalNumber != null && message.hasOwnProperty("rollingStartIntervalNumber"))
-                    if (!$util.isInteger(message.rollingStartIntervalNumber))
-                        return "rollingStartIntervalNumber: integer expected";
+                if (message.rollingStartNumber != null && message.hasOwnProperty("rollingStartNumber"))
+                    if (!$util.isInteger(message.rollingStartNumber))
+                        return "rollingStartNumber: integer expected";
                 if (message.rollingPeriod != null && message.hasOwnProperty("rollingPeriod"))
                     if (!$util.isInteger(message.rollingPeriod))
                         return "rollingPeriod: integer expected";
+                if (message.transmissionRiskLevel != null && message.hasOwnProperty("transmissionRiskLevel"))
+                    if (!$util.isInteger(message.transmissionRiskLevel))
+                        return "transmissionRiskLevel: integer expected";
                 return null;
             };
     
             /**
-             * Creates a TemporaryExposureKey message from a plain object. Also converts values to their respective internal types.
+             * Creates a Key message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
              * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey
+             * @returns {covidshield.Key} Key
              */
-            TemporaryExposureKey.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.TemporaryExposureKey)
+            Key.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.Key)
                     return object;
-                var message = new $root.covidshield.TemporaryExposureKey();
+                var message = new $root.covidshield.Key();
                 if (object.keyData != null)
                     if (typeof object.keyData === "string")
                         $util.base64.decode(object.keyData, message.keyData = $util.newBuffer($util.base64.length(object.keyData)), 0);
                     else if (object.keyData.length)
                         message.keyData = object.keyData;
+                if (object.rollingStartNumber != null)
+                    message.rollingStartNumber = object.rollingStartNumber >>> 0;
+                if (object.rollingPeriod != null)
+                    message.rollingPeriod = object.rollingPeriod >>> 0;
                 if (object.transmissionRiskLevel != null)
                     message.transmissionRiskLevel = object.transmissionRiskLevel | 0;
-                if (object.rollingStartIntervalNumber != null)
-                    message.rollingStartIntervalNumber = object.rollingStartIntervalNumber | 0;
-                if (object.rollingPeriod != null)
-                    message.rollingPeriod = object.rollingPeriod | 0;
                 return message;
             };
     
             /**
-             * Creates a plain object from a TemporaryExposureKey message. Also converts values to other types if specified.
+             * Creates a plain object from a Key message. Also converts values to other types if specified.
              * @function toObject
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @static
-             * @param {covidshield.TemporaryExposureKey} message TemporaryExposureKey
+             * @param {covidshield.Key} message Key
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TemporaryExposureKey.toObject = function toObject(message, options) {
+            Key.toObject = function toObject(message, options) {
                 if (!options)
                     options = {};
                 var object = {};
@@ -2231,509 +2103,33 @@
                         if (options.bytes !== Array)
                             object.keyData = $util.newBuffer(object.keyData);
                     }
+                    object.rollingStartNumber = 0;
+                    object.rollingPeriod = 0;
                     object.transmissionRiskLevel = 0;
-                    object.rollingStartIntervalNumber = 0;
-                    object.rollingPeriod = 144;
                 }
                 if (message.keyData != null && message.hasOwnProperty("keyData"))
                     object.keyData = options.bytes === String ? $util.base64.encode(message.keyData, 0, message.keyData.length) : options.bytes === Array ? Array.prototype.slice.call(message.keyData) : message.keyData;
-                if (message.transmissionRiskLevel != null && message.hasOwnProperty("transmissionRiskLevel"))
-                    object.transmissionRiskLevel = message.transmissionRiskLevel;
-                if (message.rollingStartIntervalNumber != null && message.hasOwnProperty("rollingStartIntervalNumber"))
-                    object.rollingStartIntervalNumber = message.rollingStartIntervalNumber;
+                if (message.rollingStartNumber != null && message.hasOwnProperty("rollingStartNumber"))
+                    object.rollingStartNumber = message.rollingStartNumber;
                 if (message.rollingPeriod != null && message.hasOwnProperty("rollingPeriod"))
                     object.rollingPeriod = message.rollingPeriod;
+                if (message.transmissionRiskLevel != null && message.hasOwnProperty("transmissionRiskLevel"))
+                    object.transmissionRiskLevel = message.transmissionRiskLevel;
                 return object;
             };
     
             /**
-             * Converts this TemporaryExposureKey to JSON.
+             * Converts this Key to JSON.
              * @function toJSON
-             * @memberof covidshield.TemporaryExposureKey
+             * @memberof covidshield.Key
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-            TemporaryExposureKey.prototype.toJSON = function toJSON() {
+            Key.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
     
-            return TemporaryExposureKey;
-        })();
-    
-        covidshield.TEKSignatureList = (function() {
-    
-            /**
-             * Properties of a TEKSignatureList.
-             * @memberof covidshield
-             * @interface ITEKSignatureList
-             * @property {Array.<covidshield.ITEKSignature>|null} [signatures] TEKSignatureList signatures
-             */
-    
-            /**
-             * Constructs a new TEKSignatureList.
-             * @memberof covidshield
-             * @classdesc Represents a TEKSignatureList.
-             * @implements ITEKSignatureList
-             * @constructor
-             * @param {covidshield.ITEKSignatureList=} [properties] Properties to set
-             */
-            function TEKSignatureList(properties) {
-                this.signatures = [];
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * TEKSignatureList signatures.
-             * @member {Array.<covidshield.ITEKSignature>} signatures
-             * @memberof covidshield.TEKSignatureList
-             * @instance
-             */
-            TEKSignatureList.prototype.signatures = $util.emptyArray;
-    
-            /**
-             * Creates a new TEKSignatureList instance using the specified properties.
-             * @function create
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {covidshield.ITEKSignatureList=} [properties] Properties to set
-             * @returns {covidshield.TEKSignatureList} TEKSignatureList instance
-             */
-            TEKSignatureList.create = function create(properties) {
-                return new TEKSignatureList(properties);
-            };
-    
-            /**
-             * Encodes the specified TEKSignatureList message. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
-             * @function encode
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {covidshield.ITEKSignatureList} message TEKSignatureList message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            TEKSignatureList.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.signatures != null && message.signatures.length)
-                    for (var i = 0; i < message.signatures.length; ++i)
-                        $root.covidshield.TEKSignature.encode(message.signatures[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified TEKSignatureList message, length delimited. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {covidshield.ITEKSignatureList} message TEKSignatureList message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            TEKSignatureList.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a TEKSignatureList message from the specified reader or buffer.
-             * @function decode
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.TEKSignatureList} TEKSignatureList
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            TEKSignatureList.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TEKSignatureList();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        if (!(message.signatures && message.signatures.length))
-                            message.signatures = [];
-                        message.signatures.push($root.covidshield.TEKSignature.decode(reader, reader.uint32()));
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a TEKSignatureList message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.TEKSignatureList} TEKSignatureList
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            TEKSignatureList.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a TEKSignatureList message.
-             * @function verify
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            TEKSignatureList.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.signatures != null && message.hasOwnProperty("signatures")) {
-                    if (!Array.isArray(message.signatures))
-                        return "signatures: array expected";
-                    for (var i = 0; i < message.signatures.length; ++i) {
-                        var error = $root.covidshield.TEKSignature.verify(message.signatures[i]);
-                        if (error)
-                            return "signatures." + error;
-                    }
-                }
-                return null;
-            };
-    
-            /**
-             * Creates a TEKSignatureList message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.TEKSignatureList} TEKSignatureList
-             */
-            TEKSignatureList.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.TEKSignatureList)
-                    return object;
-                var message = new $root.covidshield.TEKSignatureList();
-                if (object.signatures) {
-                    if (!Array.isArray(object.signatures))
-                        throw TypeError(".covidshield.TEKSignatureList.signatures: array expected");
-                    message.signatures = [];
-                    for (var i = 0; i < object.signatures.length; ++i) {
-                        if (typeof object.signatures[i] !== "object")
-                            throw TypeError(".covidshield.TEKSignatureList.signatures: object expected");
-                        message.signatures[i] = $root.covidshield.TEKSignature.fromObject(object.signatures[i]);
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a TEKSignatureList message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof covidshield.TEKSignatureList
-             * @static
-             * @param {covidshield.TEKSignatureList} message TEKSignatureList
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            TEKSignatureList.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.arrays || options.defaults)
-                    object.signatures = [];
-                if (message.signatures && message.signatures.length) {
-                    object.signatures = [];
-                    for (var j = 0; j < message.signatures.length; ++j)
-                        object.signatures[j] = $root.covidshield.TEKSignature.toObject(message.signatures[j], options);
-                }
-                return object;
-            };
-    
-            /**
-             * Converts this TEKSignatureList to JSON.
-             * @function toJSON
-             * @memberof covidshield.TEKSignatureList
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            TEKSignatureList.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return TEKSignatureList;
-        })();
-    
-        covidshield.TEKSignature = (function() {
-    
-            /**
-             * Properties of a TEKSignature.
-             * @memberof covidshield
-             * @interface ITEKSignature
-             * @property {covidshield.ISignatureInfo|null} [signatureInfo] TEKSignature signatureInfo
-             * @property {number|null} [batchNum] TEKSignature batchNum
-             * @property {number|null} [batchSize] TEKSignature batchSize
-             * @property {Uint8Array|null} [signature] TEKSignature signature
-             */
-    
-            /**
-             * Constructs a new TEKSignature.
-             * @memberof covidshield
-             * @classdesc Represents a TEKSignature.
-             * @implements ITEKSignature
-             * @constructor
-             * @param {covidshield.ITEKSignature=} [properties] Properties to set
-             */
-            function TEKSignature(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * TEKSignature signatureInfo.
-             * @member {covidshield.ISignatureInfo|null|undefined} signatureInfo
-             * @memberof covidshield.TEKSignature
-             * @instance
-             */
-            TEKSignature.prototype.signatureInfo = null;
-    
-            /**
-             * TEKSignature batchNum.
-             * @member {number} batchNum
-             * @memberof covidshield.TEKSignature
-             * @instance
-             */
-            TEKSignature.prototype.batchNum = 0;
-    
-            /**
-             * TEKSignature batchSize.
-             * @member {number} batchSize
-             * @memberof covidshield.TEKSignature
-             * @instance
-             */
-            TEKSignature.prototype.batchSize = 0;
-    
-            /**
-             * TEKSignature signature.
-             * @member {Uint8Array} signature
-             * @memberof covidshield.TEKSignature
-             * @instance
-             */
-            TEKSignature.prototype.signature = $util.newBuffer([]);
-    
-            /**
-             * Creates a new TEKSignature instance using the specified properties.
-             * @function create
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {covidshield.ITEKSignature=} [properties] Properties to set
-             * @returns {covidshield.TEKSignature} TEKSignature instance
-             */
-            TEKSignature.create = function create(properties) {
-                return new TEKSignature(properties);
-            };
-    
-            /**
-             * Encodes the specified TEKSignature message. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
-             * @function encode
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {covidshield.ITEKSignature} message TEKSignature message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            TEKSignature.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.signatureInfo != null && Object.hasOwnProperty.call(message, "signatureInfo"))
-                    $root.covidshield.SignatureInfo.encode(message.signatureInfo, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                if (message.batchNum != null && Object.hasOwnProperty.call(message, "batchNum"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.batchNum);
-                if (message.batchSize != null && Object.hasOwnProperty.call(message, "batchSize"))
-                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.batchSize);
-                if (message.signature != null && Object.hasOwnProperty.call(message, "signature"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.signature);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified TEKSignature message, length delimited. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {covidshield.ITEKSignature} message TEKSignature message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            TEKSignature.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a TEKSignature message from the specified reader or buffer.
-             * @function decode
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.TEKSignature} TEKSignature
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            TEKSignature.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TEKSignature();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.signatureInfo = $root.covidshield.SignatureInfo.decode(reader, reader.uint32());
-                        break;
-                    case 2:
-                        message.batchNum = reader.int32();
-                        break;
-                    case 3:
-                        message.batchSize = reader.int32();
-                        break;
-                    case 4:
-                        message.signature = reader.bytes();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a TEKSignature message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.TEKSignature} TEKSignature
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            TEKSignature.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a TEKSignature message.
-             * @function verify
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            TEKSignature.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.signatureInfo != null && message.hasOwnProperty("signatureInfo")) {
-                    var error = $root.covidshield.SignatureInfo.verify(message.signatureInfo);
-                    if (error)
-                        return "signatureInfo." + error;
-                }
-                if (message.batchNum != null && message.hasOwnProperty("batchNum"))
-                    if (!$util.isInteger(message.batchNum))
-                        return "batchNum: integer expected";
-                if (message.batchSize != null && message.hasOwnProperty("batchSize"))
-                    if (!$util.isInteger(message.batchSize))
-                        return "batchSize: integer expected";
-                if (message.signature != null && message.hasOwnProperty("signature"))
-                    if (!(message.signature && typeof message.signature.length === "number" || $util.isString(message.signature)))
-                        return "signature: buffer expected";
-                return null;
-            };
-    
-            /**
-             * Creates a TEKSignature message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.TEKSignature} TEKSignature
-             */
-            TEKSignature.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.TEKSignature)
-                    return object;
-                var message = new $root.covidshield.TEKSignature();
-                if (object.signatureInfo != null) {
-                    if (typeof object.signatureInfo !== "object")
-                        throw TypeError(".covidshield.TEKSignature.signatureInfo: object expected");
-                    message.signatureInfo = $root.covidshield.SignatureInfo.fromObject(object.signatureInfo);
-                }
-                if (object.batchNum != null)
-                    message.batchNum = object.batchNum | 0;
-                if (object.batchSize != null)
-                    message.batchSize = object.batchSize | 0;
-                if (object.signature != null)
-                    if (typeof object.signature === "string")
-                        $util.base64.decode(object.signature, message.signature = $util.newBuffer($util.base64.length(object.signature)), 0);
-                    else if (object.signature.length)
-                        message.signature = object.signature;
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a TEKSignature message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof covidshield.TEKSignature
-             * @static
-             * @param {covidshield.TEKSignature} message TEKSignature
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            TEKSignature.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.signatureInfo = null;
-                    object.batchNum = 0;
-                    object.batchSize = 0;
-                    if (options.bytes === String)
-                        object.signature = "";
-                    else {
-                        object.signature = [];
-                        if (options.bytes !== Array)
-                            object.signature = $util.newBuffer(object.signature);
-                    }
-                }
-                if (message.signatureInfo != null && message.hasOwnProperty("signatureInfo"))
-                    object.signatureInfo = $root.covidshield.SignatureInfo.toObject(message.signatureInfo, options);
-                if (message.batchNum != null && message.hasOwnProperty("batchNum"))
-                    object.batchNum = message.batchNum;
-                if (message.batchSize != null && message.hasOwnProperty("batchSize"))
-                    object.batchSize = message.batchSize;
-                if (message.signature != null && message.hasOwnProperty("signature"))
-                    object.signature = options.bytes === String ? $util.base64.encode(message.signature, 0, message.signature.length) : options.bytes === Array ? Array.prototype.slice.call(message.signature) : message.signature;
-                return object;
-            };
-    
-            /**
-             * Converts this TEKSignature to JSON.
-             * @function toJSON
-             * @memberof covidshield.TEKSignature
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            TEKSignature.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return TEKSignature;
+            return Key;
         })();
     
         return covidshield;

--- a/src/services/BackendService/covidshield/covidshield.proto
+++ b/src/services/BackendService/covidshield/covidshield.proto
@@ -6,23 +6,23 @@ option go_package="pkg/proto/covidshield";
 
 // Clients will receive a One Time Code via some external channel (i.e. SMS or
 // verbal). Then, upon issuing THIS request, they will generate a new keypair.
-// If the response comes back successful, the app_public_key (and the
-// corresponding private key) and the returned server_public_key will be kept in
+// If the response comes back successful, the appPublicKey (and the
+// corresponding private key) and the returned serverPublicKey will be kept in
 // local storage for the duration of this reporting window (the next 14 days).
 //
-// app_public_keys must not be re-used for new KeyClaimRequests, or the requests
+// appPublicKeys must not be re-used for new KeyClaimRequests, or the requests
 // will fail.
 message KeyClaimRequest {
-  // one_time_code is the code received from the testing portal.
-  required string one_time_code = 1; // 8 numerical digits
-  // app_public_key is generated locally and saved upon successful request
+  // oneTimeCode is the code received from the testing portal.
+  required string oneTimeCode = 1; // 8 numerical digits
+  // appPublicKey is generated locally and saved upon successful request
   // completion.
-  required bytes app_public_key = 2; // 32 bytes
+  required bytes appPublicKey = 2; // 32 bytes
 }
 
 // KeyClaimResponse is received from the server in response to a
 // KeyClaimRequest. If the request was successful, error will be NONE and
-// server_public_key will be set.
+// serverPublicKey will be set.
 message KeyClaimResponse {
   enum ErrorCode {
     NONE = 0;
@@ -33,7 +33,7 @@ message KeyClaimResponse {
     INVALID_KEY = 4;
   }
   optional ErrorCode error = 1;
-  optional bytes server_public_key = 2; // 32 bytes
+  optional bytes serverPublicKey = 2; // 32 bytes
 }
 
 // We are using a NaCl Box (Curve25519+XSalsa20+Poly1305) to encrypt and
@@ -47,16 +47,16 @@ message KeyClaimResponse {
 //
 // See "Security Model" at https://nacl.cr.yp.to/box.html
 message EncryptedUploadRequest {
-  // server_public_key is provided by the Diagnosis Server to the App, and is
+  // serverPublicKey is provided by the Diagnosis Server to the App, and is
   // used to encrypt the payload. This key should be stored locally for 14
   // days, and used to submit the follow-up Diagnosis Key.
-  required bytes server_public_key = 1; // 32 bytes
-  // app_public_key is the public side of a keypair generated once by the
-  // application and linked to the server_public_key. These are linked in the
-  // Diagnosis Server, so that only one app_public_key is authorized to upload
-  // for a given server_public_key. If a new server_public_key is issued to an App
-  // (e.g. months later), a new app_public_key should be generated.
-  required bytes app_public_key = 2; // 32 bytes
+  required bytes serverPublicKey = 1; // 32 bytes
+  // appPublicKey is the public side of a keypair generated once by the
+  // application and linked to the serverPublicKey. These are linked in the
+  // Diagnosis Server, so that only one appPublicKey is authorized to upload
+  // for a given serverPublicKey. If a new serverPublicKey is issued to an App
+  // (e.g. months later), a new appPublicKey should be generated.
+  required bytes appPublicKey = 2; // 32 bytes
   // nonce must be 24 random bytes, and absolutely must NOT be re-used between
   // subsequent submissions of Diagnosis Keys. This nonce is passed to the
   // encryption library to generate the ciphertext.
@@ -84,7 +84,7 @@ message EncryptedUploadResponse {
     INVALID_TIMESTAMP = 8;
     INVALID_ROLLING_PERIOD = 10;
     INVALID_KEY_DATA = 11;
-    INVALID_ROLLING_START_INTERVAL_NUMBER = 12;
+    INVALID_ROLLING_START_NUMBER = 12;
     INVALID_TRANSMISSION_RISK_LEVEL = 13;
   }
   required ErrorCode error = 1;
@@ -95,95 +95,35 @@ message Upload {
   // timestamp is just the current device time at message generation.
   required google.protobuf.Timestamp timestamp = 1;
   // keys returns from the ExposureNotification API.
-  repeated TemporaryExposureKey keys = 2;
+  repeated Key keys = 2;
 }
 
-// Remaining messages imported from:
-// https://developer.apple.com/documentation/exposurenotification/setting_up_an_exposure_notification_server
+// File, Header, and Key messages imported from:
+// https://developer.apple.com/documentation/exposurenotification/enmanager/3586331-detectexposures
 //
-// The format of the /keys endpoints is a stream of serialized File
+// The format of the /retrieve-* endpoints is a stream of serialized File
 // messages, each length-prefixed with a big-endian uint32. Clients should take
-// care to verify that the batch_size from the headers matches the total number
+// care to verify that the batchSize from the headers matches the total number
 // of records received.
-//
-// Note, as a special case, that if there are no keys at all in the requested
-// range, the total content of the response will be "\x00\x00\x00\x00"; that
-// is, a big-endian uint32 of zero.
 //
 // In general, we don't change or add field definitions below this point.
 
-message TemporaryExposureKeyExport {
-  // Time window of keys in the file, based on arrival
-  // at the server, in UTC seconds.
-  optional fixed64 start_timestamp = 1;
-  optional fixed64 end_timestamp = 2;
-
-  // Region from which these keys came (for example, MCC).
-  optional string region = 3;
-
-  // Reserved for future use. Both batch_num and batch_size
-  // must be set to a value of 1.
-  optional int32 batch_num = 4;
-  optional int32 batch_size = 5;
-
-  // Information about associated signatures.
-  repeated SignatureInfo signature_infos = 6;
-
-  // The temporary exposure keys themselves.
-  repeated TemporaryExposureKey keys = 7;
+message File {
+  optional Header header = 1;
+  repeated Key key = 2;
 }
 
-message SignatureInfo {
-  // App Store app bundle ID.
-  optional string app_bundle_id = 1;
-
-  // Android app package name.
-  optional string android_package = 2;
-
-  // Key version in case the EN server signing key is rotated.
-  optional string verification_key_version = 3;
-
-  // Additional information to uniquely identify the public
-  // key associated with the EN server's signing key
-  // (for example, the EN server might serve the app
-  // from different countries with different keys).
-  optional string verification_key_id = 4;
-
-  // All keys must be signed using the SHA-256 with ECDSA algorithm.
-  // This field must contain the string "ecdsa-with-SHA256".
-  optional string signature_algorithm = 5;
+message Header {
+  optional int64 startTimestamp = 1; // Time window of keys in this file based on arrival to server, in UTC.
+  optional int64 endTimestamp = 2;
+  optional string region = 3; // Region for which these keys came from (e.g., country)
+  optional int32 batchNum = 4; // E.g., if batchNum=2;batchSize=10, this is batch 2 of 10
+  optional int32 batchSize = 5;
 }
 
-message TemporaryExposureKey {
-  // Temporary exposure key.
-  optional bytes key_data = 1;
-
-  // Varying risk associated with a key depending on the diagnosis method.
-  optional int32 transmission_risk_level = 2;
-
-  // Number representing the beginning interval for temporary exposure
-  // key validity (ENIntervalNumber).
-  optional int32 rolling_start_interval_number = 3;
-
-  // Number of intervals in a period.
-  optional int32 rolling_period = 4 [default = 144];
-}
-
-message TEKSignatureList {
-  // Information about associated signatures.
-  repeated TEKSignature signatures = 1;
-}
-
-message TEKSignature {
-  // Information to uniquely identify the public key associated
-  // with the EN server's signing key.
-  optional SignatureInfo signature_info = 1;
-
-  // Reserved for future use. Both batch_num and batch_size
-  // must be set to a value of 1.
-  optional int32 batch_num = 2;
-  optional int32 batch_size = 3;
-
-  // Signature in X9.62 format (ASN.1 SEQUENCE of two INTEGER fields).
-  optional bytes signature = 4;
+message Key {
+  optional bytes keyData = 1; // Key of infected user
+  optional uint32 rollingStartNumber = 2; // Interval number when the key's EKRollingPeriod started.
+  optional uint32 rollingPeriod = 3; // Number of 10-minute windows between key rolling.
+  optional int32 transmissionRiskLevel = 4; // Risk of transmission associated with the person this key came from.
 }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -3,6 +3,10 @@ import {when} from 'jest-when';
 
 import {ExposureNotificationService} from './ExposureNotificationService';
 
+jest.mock('react-native-zip-archive', () => ({
+  unzip: jest.fn(),
+}));
+
 const server: any = {
   retrieveDiagnosisKeys: jest.fn().mockResolvedValue(null),
   getExposureConfiguration: jest.fn().mockResolvedValue({}),

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-disable require-atomic-updates */
 import {when} from 'jest-when';
 
-import {ExposureNotificationService, SystemStatus} from './ExposureNotificationService';
+import {ExposureNotificationService} from './ExposureNotificationService';
 
 const server: any = {
-  retrieveDiagnosisKeys: jest.fn().mockResolvedValue([]),
+  retrieveDiagnosisKeys: jest.fn().mockResolvedValue(null),
   getExposureConfiguration: jest.fn().mockResolvedValue({}),
   claimOneTimeCode: jest.fn(),
   reportDiagnosisKeys: jest.fn(),
@@ -22,7 +22,6 @@ const bridge: any = {
   detectExposure: jest.fn().mockResolvedValue({matchedKeyCount: 0}),
   start: jest.fn().mockResolvedValue(undefined),
   getTemporaryExposureKeyHistory: jest.fn().mockResolvedValue({}),
-  getStatus: jest.fn(),
 };
 
 describe('ExposureNotificationService', () => {
@@ -30,10 +29,8 @@ describe('ExposureNotificationService', () => {
 
   const OriginalDate = global.Date;
   const dateSpy = jest.spyOn(global, 'Date');
-
   beforeEach(() => {
     service = new ExposureNotificationService(server, translate, storage, secureStorage, bridge);
-    bridge.getStatus.mockReturnValue(Promise.resolve(SystemStatus.Active));
   });
 
   afterEach(() => {
@@ -47,22 +44,28 @@ describe('ExposureNotificationService', () => {
       .mockImplementation((args: any) => new OriginalDate(args));
 
     await service.updateExposureStatus();
-    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(168);
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(56);
   });
 
   it('backfills the right amount of keys for current day', async () => {
     dateSpy.mockImplementation((args: any) => {
-      if (args === undefined) return new OriginalDate('2020-05-19T07:10:00+0000');
+      if (args === undefined) return new OriginalDate('2020-05-19T11:10:00+0000');
       return new OriginalDate(args);
     });
 
-    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-19T04:10:00+0000').getTime());
+    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-19T06:10:00+0000').getTime());
+    await service.updateExposureStatus();
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(0);
+
+    server.retrieveDiagnosisKeys.mockClear();
+
+    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-19T05:10:00+0000').getTime());
 
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
 
     server.retrieveDiagnosisKeys.mockClear();
-    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-19T03:10:00+0000').getTime());
+    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-18T23:10:00+0000').getTime());
 
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -6,8 +6,8 @@ export function hoursSinceEpoch(date: Date) {
   return date.getTime() / (1000 * 3600);
 }
 
-export function periodSinceEpoch(date: Date) {
-  return Math.floor(date.getTime() / (1000 * 3600 * 2)) * 2;
+export function periodSinceEpoch(date: Date, hoursPerPeriod: number) {
+  return Math.floor(date.getTime() / (1000 * 3600 * hoursPerPeriod)) * hoursPerPeriod;
 }
 
 export function daysFromNow(date: Date) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7242,6 +7242,11 @@ react-native-svg@^12.1.0:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
+react-native-zip-archive@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-5.0.2.tgz#cfa2aa8c97dd4ccb2dd8c99812ec7d9e20bf7549"
+  integrity sha512-s/dSQ+XDK1aPnZ2YH1abIAWLwfylU1WptnQ0HuPVO0tahQKGQpcEgj+UQXnzPnUFHwAlTfvV7PjVyZQukNvWjw==
+
 react-native@0.62.2:
   version "0.62.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.2.tgz#d831e11a3178705449142df19a70ac2ca16bad10"


### PR DESCRIPTION
## What
This PR fixes submission flow on Android and polishes the bridge.

Resolves https://github.com/CovidShield/mobile/issues/123

## How to achieve
Cherry-pick js changes in here https://github.com/CovidShield/mobile/pull/102 and resolve broken schema. 

## How to test
- Checkout `https://github.com/CovidShield/server`, make sure all dependencies are installed (check dev.ym#up), and run the server.
- Use `ngrok` to tunnel server endpoint
```
ngrok http 8000
ngrok http 8001
```
- In this PR, changes `.env` to (use your ngrok urls)
```
APP_ID_IOS=app.covidshield
APP_ID_ANDROID=com.google.android.apps.exposurenotification
APP_VERSION_CODE=1
APP_VERSION_NAME=1.0

SUBMIT_URL=https://2c4c45ae1a78.ngrok.io
RETRIEVE_URL=https://2a78ac7e6310.ngrok.io
HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
REGION=302

TEST_MODE=true
MOCK_SERVER=false
```
- Retrieve submission key with `curl -X POST -H "Authorization: Bearer test" https://2c4c45ae1a78.ngrok.io/new-key-claim`
- Run this PR on Android and test submission flow.

## Demo

https://drive.google.com/file/d/1R7YRvMqK3Ufe0rx_klK-9s5Ai8K5hV9y/view?usp=sharing

## Outstanding
I cannot test on two devices because key retrieval doesn't work. It is blocked by backend PR https://github.com/CovidShield/server/pull/67