### PR TITLE
Fix retrieval flow on Android

### DIFF
--- a/android/app/src/main/java/app/covidshield/extensions/FileExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/FileExtensions.kt
@@ -1,0 +1,10 @@
+package app.covidshield.extensions
+
+import java.io.File
+
+fun File.cleanup() {
+    try {
+        deleteOnExit()
+    } catch (_: Exception) {
+    }
+}

--- a/android/app/src/main/java/app/covidshield/extensions/LogExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/LogExtensions.kt
@@ -3,7 +3,7 @@ package app.covidshield.extensions
 import android.util.Log
 import app.covidshield.BuildConfig
 
-fun Any.log(msg: String, tag: String = this::class.java.simpleName) {
+fun Any.log(msg: String?, tag: String = this::class.java.simpleName) {
     if (BuildConfig.DEBUG) {
         Log.d(tag, msg)
     }

--- a/android/app/src/main/java/app/covidshield/extensions/ReactNativeExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/ReactNativeExtensions.kt
@@ -22,7 +22,7 @@ fun Any.toWritableMap(): WritableMap {
 }
 
 fun <T> ReadableMap.parse(classOfT: Class<T>): T {
-    return convertMapToJson(this)!!.toJson().parse(classOfT)
+    return convertMapToJson(this)!!.toString().parse(classOfT)
 }
 
 fun <T> ReadableArray.parse(classOfT: Class<T>): List<T> {

--- a/android/app/src/main/java/app/covidshield/extensions/TemporaryExposureKeyExtensions.kt
+++ b/android/app/src/main/java/app/covidshield/extensions/TemporaryExposureKeyExtensions.kt
@@ -7,7 +7,7 @@ import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 fun TemporaryExposureKey.toExposureKey(): ExposureKey {
     return ExposureKey(
         keyData = Base64.encodeToString(keyData, Base64.NO_WRAP),
-        rollingStartNumber = rollingStartIntervalNumber,
+        rollingStartIntervalNumber = rollingStartIntervalNumber,
         rollingPeriod = rollingPeriod,
         transmissionRiskLevel = transmissionRiskLevel
     )

--- a/android/app/src/main/java/app/covidshield/models/ExposureKey.kt
+++ b/android/app/src/main/java/app/covidshield/models/ExposureKey.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ExposureKey(
     @SerializedName("keyData") val keyData: String,
-    @SerializedName("rollingStartNumber") val rollingStartNumber: Int,
+    @SerializedName("rollingStartIntervalNumber") val rollingStartIntervalNumber: Int,
     @SerializedName("rollingPeriod") val rollingPeriod: Int,
     @SerializedName("transmissionRiskLevel") val transmissionRiskLevel: Int
 )

--- a/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.io.File
 import java.io.IOException
 import java.security.SecureRandom
 import java.util.*
@@ -48,12 +49,10 @@ class CovidShieldModule(context: ReactApplicationContext) : ReactContextBaseJava
         }
     }
 
-    private fun writeFile(file: ByteArray): String {
-        // TODO: consider using cache or cleaning up old files
-        val filename = UUID.randomUUID().toString()
-        reactApplicationContext.openFileOutput(filename, Context.MODE_PRIVATE).use {
-            it.write(file)
-        }
-        return filename
+    private fun writeFile(data: ByteArray): String {
+        val dirName = UUID.randomUUID().toString()
+        val file = File(reactApplicationContext.getDir(dirName, Context.MODE_PRIVATE), "keys.zip")
+        file.outputStream().use { it.write(data) }
+        return file.absolutePath
     }
 }

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -3,7 +3,9 @@ package app.covidshield.module
 import android.app.Activity
 import android.content.Intent
 import android.content.IntentSender
+import app.covidshield.extensions.cleanup
 import app.covidshield.extensions.launch
+import app.covidshield.extensions.log
 import app.covidshield.extensions.parse
 import app.covidshield.extensions.toExposureConfiguration
 import app.covidshield.extensions.toExposureKey
@@ -94,6 +96,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
 
             exposureNotificationClient.provideDiagnosisKeys(files, exposureConfiguration, token).await()
 
+            files.forEach { it.cleanup() }
             val exposureSummary = exposureNotificationClient.getExposureSummary(token).await()
             val summary = exposureSummary.toSummary()
             promise.resolve(summary.toWritableMap().apply {
@@ -147,6 +150,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
                     startResolutionCompleter = null
                 }
             } else {
+                log(exception.message)
                 throw Exception("NO_RESOLUTION_REQUIRED", exception)
             }
         }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-native-snap-carousel": "^3.9.0",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.0",
-    "react-native-zip-archive": "^5.0.2",
     "reanimated-bottom-sheet": "^1.0.0-alpha.20",
     "tweetnacl": "^1.0.3",
     "yarn": "^1.22.4"

--- a/src/bridge/ExposureNotification.ts
+++ b/src/bridge/ExposureNotification.ts
@@ -28,7 +28,7 @@ export enum Status {
 
 export interface TemporaryExposureKey {
   keyData: string;
-  rollingStartNumber: number;
+  rollingStartIntervalNumber: number;
   rollingPeriod: number;
   transmissionRiskLevel: RiskLevel;
 }

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -3,22 +3,26 @@ import {Linking} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {Box, InfoBlock, BoxProps} from 'components';
 import {useI18n, I18n} from '@shopify/react-i18n';
-import {SystemStatus} from 'services/ExposureNotificationService';
+import {SystemStatus, useStartExposureNotificationService} from 'services/ExposureNotificationService';
 
 import {InfoShareView} from './InfoShareView';
 import {StatusHeaderView} from './StatusHeaderView';
 
 const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
-  const toSettings = useCallback(() => {
-    Linking.openSettings();
-  }, []);
+  const startExposureNotificationService = useStartExposureNotificationService();
+
+  const enableExposureNotifications = useCallback(() => {
+    console.log('ccccc enableExposureNotifications');
+    startExposureNotificationService();
+  }, [startExposureNotificationService]);
+
   return (
     <InfoBlock
       icon="icon-exposure-notifications-off"
       title={i18n.translate('OverlayOpen.ExposureNotificationCardStatus')}
       titleBolded={i18n.translate('OverlayOpen.ExposureNotificationCardStatusOff')}
       text={i18n.translate('OverlayOpen.ExposureNotificationCardBody')}
-      button={{text: i18n.translate('OverlayOpen.ExposureNotificationCardAction'), action: toSettings}}
+      button={{text: i18n.translate('OverlayOpen.ExposureNotificationCardAction'), action: enableExposureNotifications}}
       backgroundColor="errorBackground"
       color="errorText"
     />

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -24,7 +24,7 @@ export class BackendService implements BackendInterface {
   }
 
   async retrieveDiagnosisKeys(period: number) {
-    const message = `${this.region}:${period}:${Math.floor(new Date().getTime() / 1000 / 3600)}`;
+    const message = `${this.region}:${period}:${Math.floor(Date.now() / 1000 / 3600)}`;
     const hmac = hmac256(message, encHex.parse(this.hmacKey)).toString(encHex);
     return downloadDiagnosisKeysFile(`${this.retrieveUrl}/retrieve/${this.region}/${period}/${hmac}`);
   }
@@ -61,10 +61,10 @@ export class BackendService implements BackendInterface {
     const upload = covidshield.Upload.create({
       timestamp: {seconds: Math.floor(new Date().getTime() / 1000)},
       keys: exposureKeys.map(key =>
-        covidshield.Key.create({
+        covidshield.TemporaryExposureKey.create({
           keyData: Buffer.from(key.keyData, 'base64'),
           transmissionRiskLevel: key.transmissionRiskLevel,
-          rollingStartNumber: key.rollingStartNumber,
+          rollingStartIntervalNumber: key.rollingStartIntervalNumber,
           rollingPeriod: key.rollingPeriod,
         }),
       ),

--- a/src/services/BackendService/covidshield/covidshield.d.ts
+++ b/src/services/BackendService/covidshield/covidshield.d.ts
@@ -106,6 +106,12 @@ export namespace covidshield {
 
         /** KeyClaimResponse serverPublicKey */
         serverPublicKey?: (Uint8Array|null);
+
+        /** KeyClaimResponse triesRemaining */
+        triesRemaining?: (number|null);
+
+        /** KeyClaimResponse remainingBanDuration */
+        remainingBanDuration?: (google.protobuf.IDuration|null);
     }
 
     /** Represents a KeyClaimResponse. */
@@ -122,6 +128,12 @@ export namespace covidshield {
 
         /** KeyClaimResponse serverPublicKey. */
         public serverPublicKey: Uint8Array;
+
+        /** KeyClaimResponse triesRemaining. */
+        public triesRemaining: number;
+
+        /** KeyClaimResponse remainingBanDuration. */
+        public remainingBanDuration?: (google.protobuf.IDuration|null);
 
         /**
          * Creates a new KeyClaimResponse instance using the specified properties.
@@ -202,7 +214,8 @@ export namespace covidshield {
             UNKNOWN = 1,
             INVALID_ONE_TIME_CODE = 2,
             SERVER_ERROR = 3,
-            INVALID_KEY = 4
+            INVALID_KEY = 4,
+            TEMPORARY_BAN = 5
         }
     }
 
@@ -419,8 +432,9 @@ export namespace covidshield {
             INVALID_TIMESTAMP = 8,
             INVALID_ROLLING_PERIOD = 10,
             INVALID_KEY_DATA = 11,
-            INVALID_ROLLING_START_NUMBER = 12,
-            INVALID_TRANSMISSION_RISK_LEVEL = 13
+            INVALID_ROLLING_START_INTERVAL_NUMBER = 12,
+            INVALID_TRANSMISSION_RISK_LEVEL = 13,
+            NO_KEYS_IN_PAYLOAD = 14
         }
     }
 
@@ -431,7 +445,7 @@ export namespace covidshield {
         timestamp: google.protobuf.ITimestamp;
 
         /** Upload keys */
-        keys?: (covidshield.IKey[]|null);
+        keys?: (covidshield.ITemporaryExposureKey[]|null);
     }
 
     /** Represents an Upload. */
@@ -447,7 +461,7 @@ export namespace covidshield {
         public timestamp: google.protobuf.ITimestamp;
 
         /** Upload keys. */
-        public keys: covidshield.IKey[];
+        public keys: covidshield.ITemporaryExposureKey[];
 
         /**
          * Creates a new Upload instance using the specified properties.
@@ -520,319 +534,535 @@ export namespace covidshield {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a File. */
-    interface IFile {
+    /** Properties of a TemporaryExposureKeyExport. */
+    interface ITemporaryExposureKeyExport {
 
-        /** File header */
-        header?: (covidshield.IHeader|null);
-
-        /** File key */
-        key?: (covidshield.IKey[]|null);
-    }
-
-    /** Represents a File. */
-    class File implements IFile {
-
-        /**
-         * Constructs a new File.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: covidshield.IFile);
-
-        /** File header. */
-        public header?: (covidshield.IHeader|null);
-
-        /** File key. */
-        public key: covidshield.IKey[];
-
-        /**
-         * Creates a new File instance using the specified properties.
-         * @param [properties] Properties to set
-         * @returns File instance
-         */
-        public static create(properties?: covidshield.IFile): covidshield.File;
-
-        /**
-         * Encodes the specified File message. Does not implicitly {@link covidshield.File.verify|verify} messages.
-         * @param message File message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: covidshield.IFile, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified File message, length delimited. Does not implicitly {@link covidshield.File.verify|verify} messages.
-         * @param message File message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: covidshield.IFile, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a File message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns File
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.File;
-
-        /**
-         * Decodes a File message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns File
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.File;
-
-        /**
-         * Verifies a File message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a File message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns File
-         */
-        public static fromObject(object: { [k: string]: any }): covidshield.File;
-
-        /**
-         * Creates a plain object from a File message. Also converts values to other types if specified.
-         * @param message File
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: covidshield.File, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this File to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of a Header. */
-    interface IHeader {
-
-        /** Header startTimestamp */
+        /** TemporaryExposureKeyExport startTimestamp */
         startTimestamp?: (number|Long|null);
 
-        /** Header endTimestamp */
+        /** TemporaryExposureKeyExport endTimestamp */
         endTimestamp?: (number|Long|null);
 
-        /** Header region */
+        /** TemporaryExposureKeyExport region */
         region?: (string|null);
 
-        /** Header batchNum */
+        /** TemporaryExposureKeyExport batchNum */
         batchNum?: (number|null);
 
-        /** Header batchSize */
+        /** TemporaryExposureKeyExport batchSize */
         batchSize?: (number|null);
+
+        /** TemporaryExposureKeyExport signatureInfos */
+        signatureInfos?: (covidshield.ISignatureInfo[]|null);
+
+        /** TemporaryExposureKeyExport keys */
+        keys?: (covidshield.ITemporaryExposureKey[]|null);
     }
 
-    /** Represents a Header. */
-    class Header implements IHeader {
+    /** Represents a TemporaryExposureKeyExport. */
+    class TemporaryExposureKeyExport implements ITemporaryExposureKeyExport {
 
         /**
-         * Constructs a new Header.
+         * Constructs a new TemporaryExposureKeyExport.
          * @param [properties] Properties to set
          */
-        constructor(properties?: covidshield.IHeader);
+        constructor(properties?: covidshield.ITemporaryExposureKeyExport);
 
-        /** Header startTimestamp. */
+        /** TemporaryExposureKeyExport startTimestamp. */
         public startTimestamp: (number|Long);
 
-        /** Header endTimestamp. */
+        /** TemporaryExposureKeyExport endTimestamp. */
         public endTimestamp: (number|Long);
 
-        /** Header region. */
+        /** TemporaryExposureKeyExport region. */
         public region: string;
 
-        /** Header batchNum. */
+        /** TemporaryExposureKeyExport batchNum. */
         public batchNum: number;
 
-        /** Header batchSize. */
+        /** TemporaryExposureKeyExport batchSize. */
         public batchSize: number;
 
+        /** TemporaryExposureKeyExport signatureInfos. */
+        public signatureInfos: covidshield.ISignatureInfo[];
+
+        /** TemporaryExposureKeyExport keys. */
+        public keys: covidshield.ITemporaryExposureKey[];
+
         /**
-         * Creates a new Header instance using the specified properties.
+         * Creates a new TemporaryExposureKeyExport instance using the specified properties.
          * @param [properties] Properties to set
-         * @returns Header instance
+         * @returns TemporaryExposureKeyExport instance
          */
-        public static create(properties?: covidshield.IHeader): covidshield.Header;
+        public static create(properties?: covidshield.ITemporaryExposureKeyExport): covidshield.TemporaryExposureKeyExport;
 
         /**
-         * Encodes the specified Header message. Does not implicitly {@link covidshield.Header.verify|verify} messages.
-         * @param message Header message or plain object to encode
+         * Encodes the specified TemporaryExposureKeyExport message. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
+         * @param message TemporaryExposureKeyExport message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encode(message: covidshield.IHeader, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encode(message: covidshield.ITemporaryExposureKeyExport, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Encodes the specified Header message, length delimited. Does not implicitly {@link covidshield.Header.verify|verify} messages.
-         * @param message Header message or plain object to encode
+         * Encodes the specified TemporaryExposureKeyExport message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
+         * @param message TemporaryExposureKeyExport message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encodeDelimited(message: covidshield.IHeader, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encodeDelimited(message: covidshield.ITemporaryExposureKeyExport, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Decodes a Header message from the specified reader or buffer.
+         * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer.
          * @param reader Reader or buffer to decode from
          * @param [length] Message length if known beforehand
-         * @returns Header
+         * @returns TemporaryExposureKeyExport
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.Header;
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TemporaryExposureKeyExport;
 
         /**
-         * Decodes a Header message from the specified reader or buffer, length delimited.
+         * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer, length delimited.
          * @param reader Reader or buffer to decode from
-         * @returns Header
+         * @returns TemporaryExposureKeyExport
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.Header;
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TemporaryExposureKeyExport;
 
         /**
-         * Verifies a Header message.
+         * Verifies a TemporaryExposureKeyExport message.
          * @param message Plain object to verify
          * @returns `null` if valid, otherwise the reason why it is not
          */
         public static verify(message: { [k: string]: any }): (string|null);
 
         /**
-         * Creates a Header message from a plain object. Also converts values to their respective internal types.
+         * Creates a TemporaryExposureKeyExport message from a plain object. Also converts values to their respective internal types.
          * @param object Plain object
-         * @returns Header
+         * @returns TemporaryExposureKeyExport
          */
-        public static fromObject(object: { [k: string]: any }): covidshield.Header;
+        public static fromObject(object: { [k: string]: any }): covidshield.TemporaryExposureKeyExport;
 
         /**
-         * Creates a plain object from a Header message. Also converts values to other types if specified.
-         * @param message Header
+         * Creates a plain object from a TemporaryExposureKeyExport message. Also converts values to other types if specified.
+         * @param message TemporaryExposureKeyExport
          * @param [options] Conversion options
          * @returns Plain object
          */
-        public static toObject(message: covidshield.Header, options?: $protobuf.IConversionOptions): { [k: string]: any };
+        public static toObject(message: covidshield.TemporaryExposureKeyExport, options?: $protobuf.IConversionOptions): { [k: string]: any };
 
         /**
-         * Converts this Header to JSON.
+         * Converts this TemporaryExposureKeyExport to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a Key. */
-    interface IKey {
+    /** Properties of a SignatureInfo. */
+    interface ISignatureInfo {
 
-        /** Key keyData */
-        keyData?: (Uint8Array|null);
+        /** SignatureInfo verificationKeyVersion */
+        verificationKeyVersion?: (string|null);
 
-        /** Key rollingStartNumber */
-        rollingStartNumber?: (number|null);
+        /** SignatureInfo verificationKeyId */
+        verificationKeyId?: (string|null);
 
-        /** Key rollingPeriod */
-        rollingPeriod?: (number|null);
-
-        /** Key transmissionRiskLevel */
-        transmissionRiskLevel?: (number|null);
+        /** SignatureInfo signatureAlgorithm */
+        signatureAlgorithm?: (string|null);
     }
 
-    /** Represents a Key. */
-    class Key implements IKey {
+    /** Represents a SignatureInfo. */
+    class SignatureInfo implements ISignatureInfo {
 
         /**
-         * Constructs a new Key.
+         * Constructs a new SignatureInfo.
          * @param [properties] Properties to set
          */
-        constructor(properties?: covidshield.IKey);
+        constructor(properties?: covidshield.ISignatureInfo);
 
-        /** Key keyData. */
-        public keyData: Uint8Array;
+        /** SignatureInfo verificationKeyVersion. */
+        public verificationKeyVersion: string;
 
-        /** Key rollingStartNumber. */
-        public rollingStartNumber: number;
+        /** SignatureInfo verificationKeyId. */
+        public verificationKeyId: string;
 
-        /** Key rollingPeriod. */
-        public rollingPeriod: number;
-
-        /** Key transmissionRiskLevel. */
-        public transmissionRiskLevel: number;
+        /** SignatureInfo signatureAlgorithm. */
+        public signatureAlgorithm: string;
 
         /**
-         * Creates a new Key instance using the specified properties.
+         * Creates a new SignatureInfo instance using the specified properties.
          * @param [properties] Properties to set
-         * @returns Key instance
+         * @returns SignatureInfo instance
          */
-        public static create(properties?: covidshield.IKey): covidshield.Key;
+        public static create(properties?: covidshield.ISignatureInfo): covidshield.SignatureInfo;
 
         /**
-         * Encodes the specified Key message. Does not implicitly {@link covidshield.Key.verify|verify} messages.
-         * @param message Key message or plain object to encode
+         * Encodes the specified SignatureInfo message. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
+         * @param message SignatureInfo message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encode(message: covidshield.IKey, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encode(message: covidshield.ISignatureInfo, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Encodes the specified Key message, length delimited. Does not implicitly {@link covidshield.Key.verify|verify} messages.
-         * @param message Key message or plain object to encode
+         * Encodes the specified SignatureInfo message, length delimited. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
+         * @param message SignatureInfo message or plain object to encode
          * @param [writer] Writer to encode to
          * @returns Writer
          */
-        public static encodeDelimited(message: covidshield.IKey, writer?: $protobuf.Writer): $protobuf.Writer;
+        public static encodeDelimited(message: covidshield.ISignatureInfo, writer?: $protobuf.Writer): $protobuf.Writer;
 
         /**
-         * Decodes a Key message from the specified reader or buffer.
+         * Decodes a SignatureInfo message from the specified reader or buffer.
          * @param reader Reader or buffer to decode from
          * @param [length] Message length if known beforehand
-         * @returns Key
+         * @returns SignatureInfo
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.Key;
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.SignatureInfo;
 
         /**
-         * Decodes a Key message from the specified reader or buffer, length delimited.
+         * Decodes a SignatureInfo message from the specified reader or buffer, length delimited.
          * @param reader Reader or buffer to decode from
-         * @returns Key
+         * @returns SignatureInfo
          * @throws {Error} If the payload is not a reader or valid buffer
          * @throws {$protobuf.util.ProtocolError} If required fields are missing
          */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.Key;
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.SignatureInfo;
 
         /**
-         * Verifies a Key message.
+         * Verifies a SignatureInfo message.
          * @param message Plain object to verify
          * @returns `null` if valid, otherwise the reason why it is not
          */
         public static verify(message: { [k: string]: any }): (string|null);
 
         /**
-         * Creates a Key message from a plain object. Also converts values to their respective internal types.
+         * Creates a SignatureInfo message from a plain object. Also converts values to their respective internal types.
          * @param object Plain object
-         * @returns Key
+         * @returns SignatureInfo
          */
-        public static fromObject(object: { [k: string]: any }): covidshield.Key;
+        public static fromObject(object: { [k: string]: any }): covidshield.SignatureInfo;
 
         /**
-         * Creates a plain object from a Key message. Also converts values to other types if specified.
-         * @param message Key
+         * Creates a plain object from a SignatureInfo message. Also converts values to other types if specified.
+         * @param message SignatureInfo
          * @param [options] Conversion options
          * @returns Plain object
          */
-        public static toObject(message: covidshield.Key, options?: $protobuf.IConversionOptions): { [k: string]: any };
+        public static toObject(message: covidshield.SignatureInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
 
         /**
-         * Converts this Key to JSON.
+         * Converts this SignatureInfo to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a TemporaryExposureKey. */
+    interface ITemporaryExposureKey {
+
+        /** TemporaryExposureKey keyData */
+        keyData?: (Uint8Array|null);
+
+        /** TemporaryExposureKey transmissionRiskLevel */
+        transmissionRiskLevel?: (number|null);
+
+        /** TemporaryExposureKey rollingStartIntervalNumber */
+        rollingStartIntervalNumber?: (number|null);
+
+        /** TemporaryExposureKey rollingPeriod */
+        rollingPeriod?: (number|null);
+    }
+
+    /** Represents a TemporaryExposureKey. */
+    class TemporaryExposureKey implements ITemporaryExposureKey {
+
+        /**
+         * Constructs a new TemporaryExposureKey.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: covidshield.ITemporaryExposureKey);
+
+        /** TemporaryExposureKey keyData. */
+        public keyData: Uint8Array;
+
+        /** TemporaryExposureKey transmissionRiskLevel. */
+        public transmissionRiskLevel: number;
+
+        /** TemporaryExposureKey rollingStartIntervalNumber. */
+        public rollingStartIntervalNumber: number;
+
+        /** TemporaryExposureKey rollingPeriod. */
+        public rollingPeriod: number;
+
+        /**
+         * Creates a new TemporaryExposureKey instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns TemporaryExposureKey instance
+         */
+        public static create(properties?: covidshield.ITemporaryExposureKey): covidshield.TemporaryExposureKey;
+
+        /**
+         * Encodes the specified TemporaryExposureKey message. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
+         * @param message TemporaryExposureKey message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: covidshield.ITemporaryExposureKey, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified TemporaryExposureKey message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
+         * @param message TemporaryExposureKey message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: covidshield.ITemporaryExposureKey, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a TemporaryExposureKey message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns TemporaryExposureKey
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TemporaryExposureKey;
+
+        /**
+         * Decodes a TemporaryExposureKey message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns TemporaryExposureKey
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TemporaryExposureKey;
+
+        /**
+         * Verifies a TemporaryExposureKey message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a TemporaryExposureKey message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns TemporaryExposureKey
+         */
+        public static fromObject(object: { [k: string]: any }): covidshield.TemporaryExposureKey;
+
+        /**
+         * Creates a plain object from a TemporaryExposureKey message. Also converts values to other types if specified.
+         * @param message TemporaryExposureKey
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: covidshield.TemporaryExposureKey, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this TemporaryExposureKey to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a TEKSignatureList. */
+    interface ITEKSignatureList {
+
+        /** TEKSignatureList signatures */
+        signatures?: (covidshield.ITEKSignature[]|null);
+    }
+
+    /** Represents a TEKSignatureList. */
+    class TEKSignatureList implements ITEKSignatureList {
+
+        /**
+         * Constructs a new TEKSignatureList.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: covidshield.ITEKSignatureList);
+
+        /** TEKSignatureList signatures. */
+        public signatures: covidshield.ITEKSignature[];
+
+        /**
+         * Creates a new TEKSignatureList instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns TEKSignatureList instance
+         */
+        public static create(properties?: covidshield.ITEKSignatureList): covidshield.TEKSignatureList;
+
+        /**
+         * Encodes the specified TEKSignatureList message. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
+         * @param message TEKSignatureList message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: covidshield.ITEKSignatureList, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified TEKSignatureList message, length delimited. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
+         * @param message TEKSignatureList message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: covidshield.ITEKSignatureList, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a TEKSignatureList message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns TEKSignatureList
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TEKSignatureList;
+
+        /**
+         * Decodes a TEKSignatureList message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns TEKSignatureList
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TEKSignatureList;
+
+        /**
+         * Verifies a TEKSignatureList message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a TEKSignatureList message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns TEKSignatureList
+         */
+        public static fromObject(object: { [k: string]: any }): covidshield.TEKSignatureList;
+
+        /**
+         * Creates a plain object from a TEKSignatureList message. Also converts values to other types if specified.
+         * @param message TEKSignatureList
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: covidshield.TEKSignatureList, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this TEKSignatureList to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a TEKSignature. */
+    interface ITEKSignature {
+
+        /** TEKSignature signatureInfo */
+        signatureInfo?: (covidshield.ISignatureInfo|null);
+
+        /** TEKSignature batchNum */
+        batchNum?: (number|null);
+
+        /** TEKSignature batchSize */
+        batchSize?: (number|null);
+
+        /** TEKSignature signature */
+        signature?: (Uint8Array|null);
+    }
+
+    /** Represents a TEKSignature. */
+    class TEKSignature implements ITEKSignature {
+
+        /**
+         * Constructs a new TEKSignature.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: covidshield.ITEKSignature);
+
+        /** TEKSignature signatureInfo. */
+        public signatureInfo?: (covidshield.ISignatureInfo|null);
+
+        /** TEKSignature batchNum. */
+        public batchNum: number;
+
+        /** TEKSignature batchSize. */
+        public batchSize: number;
+
+        /** TEKSignature signature. */
+        public signature: Uint8Array;
+
+        /**
+         * Creates a new TEKSignature instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns TEKSignature instance
+         */
+        public static create(properties?: covidshield.ITEKSignature): covidshield.TEKSignature;
+
+        /**
+         * Encodes the specified TEKSignature message. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
+         * @param message TEKSignature message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: covidshield.ITEKSignature, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified TEKSignature message, length delimited. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
+         * @param message TEKSignature message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: covidshield.ITEKSignature, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a TEKSignature message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns TEKSignature
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): covidshield.TEKSignature;
+
+        /**
+         * Decodes a TEKSignature message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns TEKSignature
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): covidshield.TEKSignature;
+
+        /**
+         * Verifies a TEKSignature message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a TEKSignature message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns TEKSignature
+         */
+        public static fromObject(object: { [k: string]: any }): covidshield.TEKSignature;
+
+        /**
+         * Creates a plain object from a TEKSignature message. Also converts values to other types if specified.
+         * @param message TEKSignature
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: covidshield.TEKSignature, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this TEKSignature to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -936,6 +1166,102 @@ export namespace google {
 
             /**
              * Converts this Timestamp to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a Duration. */
+        interface IDuration {
+
+            /** Duration seconds */
+            seconds?: (number|Long|null);
+
+            /** Duration nanos */
+            nanos?: (number|null);
+        }
+
+        /** Represents a Duration. */
+        class Duration implements IDuration {
+
+            /**
+             * Constructs a new Duration.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IDuration);
+
+            /** Duration seconds. */
+            public seconds: (number|Long);
+
+            /** Duration nanos. */
+            public nanos: number;
+
+            /**
+             * Creates a new Duration instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Duration instance
+             */
+            public static create(properties?: google.protobuf.IDuration): google.protobuf.Duration;
+
+            /**
+             * Encodes the specified Duration message. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+             * @param message Duration message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IDuration, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Duration message, length delimited. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+             * @param message Duration message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IDuration, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a Duration message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Duration
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Duration;
+
+            /**
+             * Decodes a Duration message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Duration
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Duration;
+
+            /**
+             * Verifies a Duration message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a Duration message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Duration
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.Duration;
+
+            /**
+             * Creates a plain object from a Duration message. Also converts values to other types if specified.
+             * @param message Duration
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.Duration, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Duration to JSON.
              * @returns JSON object
              */
             public toJSON(): { [k: string]: any };

--- a/src/services/BackendService/covidshield/covidshield.js
+++ b/src/services/BackendService/covidshield/covidshield.js
@@ -252,6 +252,8 @@
              * @interface IKeyClaimResponse
              * @property {covidshield.KeyClaimResponse.ErrorCode|null} [error] KeyClaimResponse error
              * @property {Uint8Array|null} [serverPublicKey] KeyClaimResponse serverPublicKey
+             * @property {number|null} [triesRemaining] KeyClaimResponse triesRemaining
+             * @property {google.protobuf.IDuration|null} [remainingBanDuration] KeyClaimResponse remainingBanDuration
              */
     
             /**
@@ -286,6 +288,22 @@
             KeyClaimResponse.prototype.serverPublicKey = $util.newBuffer([]);
     
             /**
+             * KeyClaimResponse triesRemaining.
+             * @member {number} triesRemaining
+             * @memberof covidshield.KeyClaimResponse
+             * @instance
+             */
+            KeyClaimResponse.prototype.triesRemaining = 0;
+    
+            /**
+             * KeyClaimResponse remainingBanDuration.
+             * @member {google.protobuf.IDuration|null|undefined} remainingBanDuration
+             * @memberof covidshield.KeyClaimResponse
+             * @instance
+             */
+            KeyClaimResponse.prototype.remainingBanDuration = null;
+    
+            /**
              * Creates a new KeyClaimResponse instance using the specified properties.
              * @function create
              * @memberof covidshield.KeyClaimResponse
@@ -313,6 +331,10 @@
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.error);
                 if (message.serverPublicKey != null && Object.hasOwnProperty.call(message, "serverPublicKey"))
                     writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.serverPublicKey);
+                if (message.triesRemaining != null && Object.hasOwnProperty.call(message, "triesRemaining"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.triesRemaining);
+                if (message.remainingBanDuration != null && Object.hasOwnProperty.call(message, "remainingBanDuration"))
+                    $root.google.protobuf.Duration.encode(message.remainingBanDuration, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                 return writer;
             };
     
@@ -352,6 +374,12 @@
                         break;
                     case 2:
                         message.serverPublicKey = reader.bytes();
+                        break;
+                    case 3:
+                        message.triesRemaining = reader.uint32();
+                        break;
+                    case 4:
+                        message.remainingBanDuration = $root.google.protobuf.Duration.decode(reader, reader.uint32());
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -397,11 +425,20 @@
                     case 2:
                     case 3:
                     case 4:
+                    case 5:
                         break;
                     }
                 if (message.serverPublicKey != null && message.hasOwnProperty("serverPublicKey"))
                     if (!(message.serverPublicKey && typeof message.serverPublicKey.length === "number" || $util.isString(message.serverPublicKey)))
                         return "serverPublicKey: buffer expected";
+                if (message.triesRemaining != null && message.hasOwnProperty("triesRemaining"))
+                    if (!$util.isInteger(message.triesRemaining))
+                        return "triesRemaining: integer expected";
+                if (message.remainingBanDuration != null && message.hasOwnProperty("remainingBanDuration")) {
+                    var error = $root.google.protobuf.Duration.verify(message.remainingBanDuration);
+                    if (error)
+                        return "remainingBanDuration." + error;
+                }
                 return null;
             };
     
@@ -438,12 +475,23 @@
                 case 4:
                     message.error = 4;
                     break;
+                case "TEMPORARY_BAN":
+                case 5:
+                    message.error = 5;
+                    break;
                 }
                 if (object.serverPublicKey != null)
                     if (typeof object.serverPublicKey === "string")
                         $util.base64.decode(object.serverPublicKey, message.serverPublicKey = $util.newBuffer($util.base64.length(object.serverPublicKey)), 0);
                     else if (object.serverPublicKey.length)
                         message.serverPublicKey = object.serverPublicKey;
+                if (object.triesRemaining != null)
+                    message.triesRemaining = object.triesRemaining >>> 0;
+                if (object.remainingBanDuration != null) {
+                    if (typeof object.remainingBanDuration !== "object")
+                        throw TypeError(".covidshield.KeyClaimResponse.remainingBanDuration: object expected");
+                    message.remainingBanDuration = $root.google.protobuf.Duration.fromObject(object.remainingBanDuration);
+                }
                 return message;
             };
     
@@ -469,11 +517,17 @@
                         if (options.bytes !== Array)
                             object.serverPublicKey = $util.newBuffer(object.serverPublicKey);
                     }
+                    object.triesRemaining = 0;
+                    object.remainingBanDuration = null;
                 }
                 if (message.error != null && message.hasOwnProperty("error"))
                     object.error = options.enums === String ? $root.covidshield.KeyClaimResponse.ErrorCode[message.error] : message.error;
                 if (message.serverPublicKey != null && message.hasOwnProperty("serverPublicKey"))
                     object.serverPublicKey = options.bytes === String ? $util.base64.encode(message.serverPublicKey, 0, message.serverPublicKey.length) : options.bytes === Array ? Array.prototype.slice.call(message.serverPublicKey) : message.serverPublicKey;
+                if (message.triesRemaining != null && message.hasOwnProperty("triesRemaining"))
+                    object.triesRemaining = message.triesRemaining;
+                if (message.remainingBanDuration != null && message.hasOwnProperty("remainingBanDuration"))
+                    object.remainingBanDuration = $root.google.protobuf.Duration.toObject(message.remainingBanDuration, options);
                 return object;
             };
     
@@ -497,6 +551,7 @@
              * @property {number} INVALID_ONE_TIME_CODE=2 INVALID_ONE_TIME_CODE value
              * @property {number} SERVER_ERROR=3 SERVER_ERROR value
              * @property {number} INVALID_KEY=4 INVALID_KEY value
+             * @property {number} TEMPORARY_BAN=5 TEMPORARY_BAN value
              */
             KeyClaimResponse.ErrorCode = (function() {
                 var valuesById = {}, values = Object.create(valuesById);
@@ -505,6 +560,7 @@
                 values[valuesById[2] = "INVALID_ONE_TIME_CODE"] = 2;
                 values[valuesById[3] = "SERVER_ERROR"] = 3;
                 values[valuesById[4] = "INVALID_KEY"] = 4;
+                values[valuesById[5] = "TEMPORARY_BAN"] = 5;
                 return values;
             })();
     
@@ -948,6 +1004,7 @@
                 case 11:
                 case 12:
                 case 13:
+                case 14:
                     break;
                 }
                 return null;
@@ -1010,13 +1067,17 @@
                 case 11:
                     message.error = 11;
                     break;
-                case "INVALID_ROLLING_START_NUMBER":
+                case "INVALID_ROLLING_START_INTERVAL_NUMBER":
                 case 12:
                     message.error = 12;
                     break;
                 case "INVALID_TRANSMISSION_RISK_LEVEL":
                 case 13:
                     message.error = 13;
+                    break;
+                case "NO_KEYS_IN_PAYLOAD":
+                case 14:
+                    message.error = 14;
                     break;
                 }
                 return message;
@@ -1068,8 +1129,9 @@
              * @property {number} INVALID_TIMESTAMP=8 INVALID_TIMESTAMP value
              * @property {number} INVALID_ROLLING_PERIOD=10 INVALID_ROLLING_PERIOD value
              * @property {number} INVALID_KEY_DATA=11 INVALID_KEY_DATA value
-             * @property {number} INVALID_ROLLING_START_NUMBER=12 INVALID_ROLLING_START_NUMBER value
+             * @property {number} INVALID_ROLLING_START_INTERVAL_NUMBER=12 INVALID_ROLLING_START_INTERVAL_NUMBER value
              * @property {number} INVALID_TRANSMISSION_RISK_LEVEL=13 INVALID_TRANSMISSION_RISK_LEVEL value
+             * @property {number} NO_KEYS_IN_PAYLOAD=14 NO_KEYS_IN_PAYLOAD value
              */
             EncryptedUploadResponse.ErrorCode = (function() {
                 var valuesById = {}, values = Object.create(valuesById);
@@ -1084,8 +1146,9 @@
                 values[valuesById[8] = "INVALID_TIMESTAMP"] = 8;
                 values[valuesById[10] = "INVALID_ROLLING_PERIOD"] = 10;
                 values[valuesById[11] = "INVALID_KEY_DATA"] = 11;
-                values[valuesById[12] = "INVALID_ROLLING_START_NUMBER"] = 12;
+                values[valuesById[12] = "INVALID_ROLLING_START_INTERVAL_NUMBER"] = 12;
                 values[valuesById[13] = "INVALID_TRANSMISSION_RISK_LEVEL"] = 13;
+                values[valuesById[14] = "NO_KEYS_IN_PAYLOAD"] = 14;
                 return values;
             })();
     
@@ -1099,7 +1162,7 @@
              * @memberof covidshield
              * @interface IUpload
              * @property {google.protobuf.ITimestamp} timestamp Upload timestamp
-             * @property {Array.<covidshield.IKey>|null} [keys] Upload keys
+             * @property {Array.<covidshield.ITemporaryExposureKey>|null} [keys] Upload keys
              */
     
             /**
@@ -1128,7 +1191,7 @@
     
             /**
              * Upload keys.
-             * @member {Array.<covidshield.IKey>} keys
+             * @member {Array.<covidshield.ITemporaryExposureKey>} keys
              * @memberof covidshield.Upload
              * @instance
              */
@@ -1161,7 +1224,7 @@
                 $root.google.protobuf.Timestamp.encode(message.timestamp, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
                 if (message.keys != null && message.keys.length)
                     for (var i = 0; i < message.keys.length; ++i)
-                        $root.covidshield.Key.encode(message.keys[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.covidshield.TemporaryExposureKey.encode(message.keys[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 return writer;
             };
     
@@ -1202,7 +1265,7 @@
                     case 2:
                         if (!(message.keys && message.keys.length))
                             message.keys = [];
-                        message.keys.push($root.covidshield.Key.decode(reader, reader.uint32()));
+                        message.keys.push($root.covidshield.TemporaryExposureKey.decode(reader, reader.uint32()));
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -1250,7 +1313,7 @@
                     if (!Array.isArray(message.keys))
                         return "keys: array expected";
                     for (var i = 0; i < message.keys.length; ++i) {
-                        var error = $root.covidshield.Key.verify(message.keys[i]);
+                        var error = $root.covidshield.TemporaryExposureKey.verify(message.keys[i]);
                         if (error)
                             return "keys." + error;
                     }
@@ -1282,7 +1345,7 @@
                     for (var i = 0; i < object.keys.length; ++i) {
                         if (typeof object.keys[i] !== "object")
                             throw TypeError(".covidshield.Upload.keys: object expected");
-                        message.keys[i] = $root.covidshield.Key.fromObject(object.keys[i]);
+                        message.keys[i] = $root.covidshield.TemporaryExposureKey.fromObject(object.keys[i]);
                     }
                 }
                 return message;
@@ -1310,7 +1373,7 @@
                 if (message.keys && message.keys.length) {
                     object.keys = [];
                     for (var j = 0; j < message.keys.length; ++j)
-                        object.keys[j] = $root.covidshield.Key.toObject(message.keys[j], options);
+                        object.keys[j] = $root.covidshield.TemporaryExposureKey.toObject(message.keys[j], options);
                 }
                 return object;
             };
@@ -1329,26 +1392,32 @@
             return Upload;
         })();
     
-        covidshield.File = (function() {
+        covidshield.TemporaryExposureKeyExport = (function() {
     
             /**
-             * Properties of a File.
+             * Properties of a TemporaryExposureKeyExport.
              * @memberof covidshield
-             * @interface IFile
-             * @property {covidshield.IHeader|null} [header] File header
-             * @property {Array.<covidshield.IKey>|null} [key] File key
+             * @interface ITemporaryExposureKeyExport
+             * @property {number|Long|null} [startTimestamp] TemporaryExposureKeyExport startTimestamp
+             * @property {number|Long|null} [endTimestamp] TemporaryExposureKeyExport endTimestamp
+             * @property {string|null} [region] TemporaryExposureKeyExport region
+             * @property {number|null} [batchNum] TemporaryExposureKeyExport batchNum
+             * @property {number|null} [batchSize] TemporaryExposureKeyExport batchSize
+             * @property {Array.<covidshield.ISignatureInfo>|null} [signatureInfos] TemporaryExposureKeyExport signatureInfos
+             * @property {Array.<covidshield.ITemporaryExposureKey>|null} [keys] TemporaryExposureKeyExport keys
              */
     
             /**
-             * Constructs a new File.
+             * Constructs a new TemporaryExposureKeyExport.
              * @memberof covidshield
-             * @classdesc Represents a File.
-             * @implements IFile
+             * @classdesc Represents a TemporaryExposureKeyExport.
+             * @implements ITemporaryExposureKeyExport
              * @constructor
-             * @param {covidshield.IFile=} [properties] Properties to set
+             * @param {covidshield.ITemporaryExposureKeyExport=} [properties] Properties to set
              */
-            function File(properties) {
-                this.key = [];
+            function TemporaryExposureKeyExport(properties) {
+                this.signatureInfos = [];
+                this.keys = [];
                 if (properties)
                     for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                         if (properties[keys[i]] != null)
@@ -1356,356 +1425,140 @@
             }
     
             /**
-             * File header.
-             * @member {covidshield.IHeader|null|undefined} header
-             * @memberof covidshield.File
-             * @instance
-             */
-            File.prototype.header = null;
-    
-            /**
-             * File key.
-             * @member {Array.<covidshield.IKey>} key
-             * @memberof covidshield.File
-             * @instance
-             */
-            File.prototype.key = $util.emptyArray;
-    
-            /**
-             * Creates a new File instance using the specified properties.
-             * @function create
-             * @memberof covidshield.File
-             * @static
-             * @param {covidshield.IFile=} [properties] Properties to set
-             * @returns {covidshield.File} File instance
-             */
-            File.create = function create(properties) {
-                return new File(properties);
-            };
-    
-            /**
-             * Encodes the specified File message. Does not implicitly {@link covidshield.File.verify|verify} messages.
-             * @function encode
-             * @memberof covidshield.File
-             * @static
-             * @param {covidshield.IFile} message File message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            File.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.header != null && Object.hasOwnProperty.call(message, "header"))
-                    $root.covidshield.Header.encode(message.header, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                if (message.key != null && message.key.length)
-                    for (var i = 0; i < message.key.length; ++i)
-                        $root.covidshield.Key.encode(message.key[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified File message, length delimited. Does not implicitly {@link covidshield.File.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof covidshield.File
-             * @static
-             * @param {covidshield.IFile} message File message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            File.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a File message from the specified reader or buffer.
-             * @function decode
-             * @memberof covidshield.File
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.File} File
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            File.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.File();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.header = $root.covidshield.Header.decode(reader, reader.uint32());
-                        break;
-                    case 2:
-                        if (!(message.key && message.key.length))
-                            message.key = [];
-                        message.key.push($root.covidshield.Key.decode(reader, reader.uint32()));
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a File message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof covidshield.File
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.File} File
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            File.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a File message.
-             * @function verify
-             * @memberof covidshield.File
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            File.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.header != null && message.hasOwnProperty("header")) {
-                    var error = $root.covidshield.Header.verify(message.header);
-                    if (error)
-                        return "header." + error;
-                }
-                if (message.key != null && message.hasOwnProperty("key")) {
-                    if (!Array.isArray(message.key))
-                        return "key: array expected";
-                    for (var i = 0; i < message.key.length; ++i) {
-                        var error = $root.covidshield.Key.verify(message.key[i]);
-                        if (error)
-                            return "key." + error;
-                    }
-                }
-                return null;
-            };
-    
-            /**
-             * Creates a File message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof covidshield.File
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.File} File
-             */
-            File.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.File)
-                    return object;
-                var message = new $root.covidshield.File();
-                if (object.header != null) {
-                    if (typeof object.header !== "object")
-                        throw TypeError(".covidshield.File.header: object expected");
-                    message.header = $root.covidshield.Header.fromObject(object.header);
-                }
-                if (object.key) {
-                    if (!Array.isArray(object.key))
-                        throw TypeError(".covidshield.File.key: array expected");
-                    message.key = [];
-                    for (var i = 0; i < object.key.length; ++i) {
-                        if (typeof object.key[i] !== "object")
-                            throw TypeError(".covidshield.File.key: object expected");
-                        message.key[i] = $root.covidshield.Key.fromObject(object.key[i]);
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a File message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof covidshield.File
-             * @static
-             * @param {covidshield.File} message File
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            File.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.arrays || options.defaults)
-                    object.key = [];
-                if (options.defaults)
-                    object.header = null;
-                if (message.header != null && message.hasOwnProperty("header"))
-                    object.header = $root.covidshield.Header.toObject(message.header, options);
-                if (message.key && message.key.length) {
-                    object.key = [];
-                    for (var j = 0; j < message.key.length; ++j)
-                        object.key[j] = $root.covidshield.Key.toObject(message.key[j], options);
-                }
-                return object;
-            };
-    
-            /**
-             * Converts this File to JSON.
-             * @function toJSON
-             * @memberof covidshield.File
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            File.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return File;
-        })();
-    
-        covidshield.Header = (function() {
-    
-            /**
-             * Properties of a Header.
-             * @memberof covidshield
-             * @interface IHeader
-             * @property {number|Long|null} [startTimestamp] Header startTimestamp
-             * @property {number|Long|null} [endTimestamp] Header endTimestamp
-             * @property {string|null} [region] Header region
-             * @property {number|null} [batchNum] Header batchNum
-             * @property {number|null} [batchSize] Header batchSize
-             */
-    
-            /**
-             * Constructs a new Header.
-             * @memberof covidshield
-             * @classdesc Represents a Header.
-             * @implements IHeader
-             * @constructor
-             * @param {covidshield.IHeader=} [properties] Properties to set
-             */
-            function Header(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * Header startTimestamp.
+             * TemporaryExposureKeyExport startTimestamp.
              * @member {number|Long} startTimestamp
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @instance
              */
-            Header.prototype.startTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+            TemporaryExposureKeyExport.prototype.startTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
     
             /**
-             * Header endTimestamp.
+             * TemporaryExposureKeyExport endTimestamp.
              * @member {number|Long} endTimestamp
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @instance
              */
-            Header.prototype.endTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+            TemporaryExposureKeyExport.prototype.endTimestamp = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
     
             /**
-             * Header region.
+             * TemporaryExposureKeyExport region.
              * @member {string} region
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @instance
              */
-            Header.prototype.region = "";
+            TemporaryExposureKeyExport.prototype.region = "";
     
             /**
-             * Header batchNum.
+             * TemporaryExposureKeyExport batchNum.
              * @member {number} batchNum
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @instance
              */
-            Header.prototype.batchNum = 0;
+            TemporaryExposureKeyExport.prototype.batchNum = 0;
     
             /**
-             * Header batchSize.
+             * TemporaryExposureKeyExport batchSize.
              * @member {number} batchSize
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @instance
              */
-            Header.prototype.batchSize = 0;
+            TemporaryExposureKeyExport.prototype.batchSize = 0;
     
             /**
-             * Creates a new Header instance using the specified properties.
-             * @function create
-             * @memberof covidshield.Header
-             * @static
-             * @param {covidshield.IHeader=} [properties] Properties to set
-             * @returns {covidshield.Header} Header instance
+             * TemporaryExposureKeyExport signatureInfos.
+             * @member {Array.<covidshield.ISignatureInfo>} signatureInfos
+             * @memberof covidshield.TemporaryExposureKeyExport
+             * @instance
              */
-            Header.create = function create(properties) {
-                return new Header(properties);
+            TemporaryExposureKeyExport.prototype.signatureInfos = $util.emptyArray;
+    
+            /**
+             * TemporaryExposureKeyExport keys.
+             * @member {Array.<covidshield.ITemporaryExposureKey>} keys
+             * @memberof covidshield.TemporaryExposureKeyExport
+             * @instance
+             */
+            TemporaryExposureKeyExport.prototype.keys = $util.emptyArray;
+    
+            /**
+             * Creates a new TemporaryExposureKeyExport instance using the specified properties.
+             * @function create
+             * @memberof covidshield.TemporaryExposureKeyExport
+             * @static
+             * @param {covidshield.ITemporaryExposureKeyExport=} [properties] Properties to set
+             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport instance
+             */
+            TemporaryExposureKeyExport.create = function create(properties) {
+                return new TemporaryExposureKeyExport(properties);
             };
     
             /**
-             * Encodes the specified Header message. Does not implicitly {@link covidshield.Header.verify|verify} messages.
+             * Encodes the specified TemporaryExposureKeyExport message. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
              * @function encode
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
-             * @param {covidshield.IHeader} message Header message or plain object to encode
+             * @param {covidshield.ITemporaryExposureKeyExport} message TemporaryExposureKeyExport message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Header.encode = function encode(message, writer) {
+            TemporaryExposureKeyExport.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
                 if (message.startTimestamp != null && Object.hasOwnProperty.call(message, "startTimestamp"))
-                    writer.uint32(/* id 1, wireType 0 =*/8).int64(message.startTimestamp);
+                    writer.uint32(/* id 1, wireType 1 =*/9).fixed64(message.startTimestamp);
                 if (message.endTimestamp != null && Object.hasOwnProperty.call(message, "endTimestamp"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).int64(message.endTimestamp);
+                    writer.uint32(/* id 2, wireType 1 =*/17).fixed64(message.endTimestamp);
                 if (message.region != null && Object.hasOwnProperty.call(message, "region"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.region);
                 if (message.batchNum != null && Object.hasOwnProperty.call(message, "batchNum"))
                     writer.uint32(/* id 4, wireType 0 =*/32).int32(message.batchNum);
                 if (message.batchSize != null && Object.hasOwnProperty.call(message, "batchSize"))
                     writer.uint32(/* id 5, wireType 0 =*/40).int32(message.batchSize);
+                if (message.signatureInfos != null && message.signatureInfos.length)
+                    for (var i = 0; i < message.signatureInfos.length; ++i)
+                        $root.covidshield.SignatureInfo.encode(message.signatureInfos[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                if (message.keys != null && message.keys.length)
+                    for (var i = 0; i < message.keys.length; ++i)
+                        $root.covidshield.TemporaryExposureKey.encode(message.keys[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
                 return writer;
             };
     
             /**
-             * Encodes the specified Header message, length delimited. Does not implicitly {@link covidshield.Header.verify|verify} messages.
+             * Encodes the specified TemporaryExposureKeyExport message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKeyExport.verify|verify} messages.
              * @function encodeDelimited
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
-             * @param {covidshield.IHeader} message Header message or plain object to encode
+             * @param {covidshield.ITemporaryExposureKeyExport} message TemporaryExposureKeyExport message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Header.encodeDelimited = function encodeDelimited(message, writer) {
+            TemporaryExposureKeyExport.encodeDelimited = function encodeDelimited(message, writer) {
                 return this.encode(message, writer).ldelim();
             };
     
             /**
-             * Decodes a Header message from the specified reader or buffer.
+             * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer.
              * @function decode
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
              * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.Header} Header
+             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Header.decode = function decode(reader, length) {
+            TemporaryExposureKeyExport.decode = function decode(reader, length) {
                 if (!(reader instanceof $Reader))
                     reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.Header();
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TemporaryExposureKeyExport();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     case 1:
-                        message.startTimestamp = reader.int64();
+                        message.startTimestamp = reader.fixed64();
                         break;
                     case 2:
-                        message.endTimestamp = reader.int64();
+                        message.endTimestamp = reader.fixed64();
                         break;
                     case 3:
                         message.region = reader.string();
@@ -1716,6 +1569,16 @@
                     case 5:
                         message.batchSize = reader.int32();
                         break;
+                    case 6:
+                        if (!(message.signatureInfos && message.signatureInfos.length))
+                            message.signatureInfos = [];
+                        message.signatureInfos.push($root.covidshield.SignatureInfo.decode(reader, reader.uint32()));
+                        break;
+                    case 7:
+                        if (!(message.keys && message.keys.length))
+                            message.keys = [];
+                        message.keys.push($root.covidshield.TemporaryExposureKey.decode(reader, reader.uint32()));
+                        break;
                     default:
                         reader.skipType(tag & 7);
                         break;
@@ -1725,30 +1588,30 @@
             };
     
             /**
-             * Decodes a Header message from the specified reader or buffer, length delimited.
+             * Decodes a TemporaryExposureKeyExport message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.Header} Header
+             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Header.decodeDelimited = function decodeDelimited(reader) {
+            TemporaryExposureKeyExport.decodeDelimited = function decodeDelimited(reader) {
                 if (!(reader instanceof $Reader))
                     reader = new $Reader(reader);
                 return this.decode(reader, reader.uint32());
             };
     
             /**
-             * Verifies a Header message.
+             * Verifies a TemporaryExposureKeyExport message.
              * @function verify
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-            Header.verify = function verify(message) {
+            TemporaryExposureKeyExport.verify = function verify(message) {
                 if (typeof message !== "object" || message === null)
                     return "object expected";
                 if (message.startTimestamp != null && message.hasOwnProperty("startTimestamp"))
@@ -1766,21 +1629,39 @@
                 if (message.batchSize != null && message.hasOwnProperty("batchSize"))
                     if (!$util.isInteger(message.batchSize))
                         return "batchSize: integer expected";
+                if (message.signatureInfos != null && message.hasOwnProperty("signatureInfos")) {
+                    if (!Array.isArray(message.signatureInfos))
+                        return "signatureInfos: array expected";
+                    for (var i = 0; i < message.signatureInfos.length; ++i) {
+                        var error = $root.covidshield.SignatureInfo.verify(message.signatureInfos[i]);
+                        if (error)
+                            return "signatureInfos." + error;
+                    }
+                }
+                if (message.keys != null && message.hasOwnProperty("keys")) {
+                    if (!Array.isArray(message.keys))
+                        return "keys: array expected";
+                    for (var i = 0; i < message.keys.length; ++i) {
+                        var error = $root.covidshield.TemporaryExposureKey.verify(message.keys[i]);
+                        if (error)
+                            return "keys." + error;
+                    }
+                }
                 return null;
             };
     
             /**
-             * Creates a Header message from a plain object. Also converts values to their respective internal types.
+             * Creates a TemporaryExposureKeyExport message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
              * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.Header} Header
+             * @returns {covidshield.TemporaryExposureKeyExport} TemporaryExposureKeyExport
              */
-            Header.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.Header)
+            TemporaryExposureKeyExport.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.TemporaryExposureKeyExport)
                     return object;
-                var message = new $root.covidshield.Header();
+                var message = new $root.covidshield.TemporaryExposureKeyExport();
                 if (object.startTimestamp != null)
                     if ($util.Long)
                         (message.startTimestamp = $util.Long.fromValue(object.startTimestamp)).unsigned = false;
@@ -1805,22 +1686,46 @@
                     message.batchNum = object.batchNum | 0;
                 if (object.batchSize != null)
                     message.batchSize = object.batchSize | 0;
+                if (object.signatureInfos) {
+                    if (!Array.isArray(object.signatureInfos))
+                        throw TypeError(".covidshield.TemporaryExposureKeyExport.signatureInfos: array expected");
+                    message.signatureInfos = [];
+                    for (var i = 0; i < object.signatureInfos.length; ++i) {
+                        if (typeof object.signatureInfos[i] !== "object")
+                            throw TypeError(".covidshield.TemporaryExposureKeyExport.signatureInfos: object expected");
+                        message.signatureInfos[i] = $root.covidshield.SignatureInfo.fromObject(object.signatureInfos[i]);
+                    }
+                }
+                if (object.keys) {
+                    if (!Array.isArray(object.keys))
+                        throw TypeError(".covidshield.TemporaryExposureKeyExport.keys: array expected");
+                    message.keys = [];
+                    for (var i = 0; i < object.keys.length; ++i) {
+                        if (typeof object.keys[i] !== "object")
+                            throw TypeError(".covidshield.TemporaryExposureKeyExport.keys: object expected");
+                        message.keys[i] = $root.covidshield.TemporaryExposureKey.fromObject(object.keys[i]);
+                    }
+                }
                 return message;
             };
     
             /**
-             * Creates a plain object from a Header message. Also converts values to other types if specified.
+             * Creates a plain object from a TemporaryExposureKeyExport message. Also converts values to other types if specified.
              * @function toObject
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @static
-             * @param {covidshield.Header} message Header
+             * @param {covidshield.TemporaryExposureKeyExport} message TemporaryExposureKeyExport
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Header.toObject = function toObject(message, options) {
+            TemporaryExposureKeyExport.toObject = function toObject(message, options) {
                 if (!options)
                     options = {};
                 var object = {};
+                if (options.arrays || options.defaults) {
+                    object.signatureInfos = [];
+                    object.keys = [];
+                }
                 if (options.defaults) {
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, false);
@@ -1852,44 +1757,53 @@
                     object.batchNum = message.batchNum;
                 if (message.batchSize != null && message.hasOwnProperty("batchSize"))
                     object.batchSize = message.batchSize;
+                if (message.signatureInfos && message.signatureInfos.length) {
+                    object.signatureInfos = [];
+                    for (var j = 0; j < message.signatureInfos.length; ++j)
+                        object.signatureInfos[j] = $root.covidshield.SignatureInfo.toObject(message.signatureInfos[j], options);
+                }
+                if (message.keys && message.keys.length) {
+                    object.keys = [];
+                    for (var j = 0; j < message.keys.length; ++j)
+                        object.keys[j] = $root.covidshield.TemporaryExposureKey.toObject(message.keys[j], options);
+                }
                 return object;
             };
     
             /**
-             * Converts this Header to JSON.
+             * Converts this TemporaryExposureKeyExport to JSON.
              * @function toJSON
-             * @memberof covidshield.Header
+             * @memberof covidshield.TemporaryExposureKeyExport
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-            Header.prototype.toJSON = function toJSON() {
+            TemporaryExposureKeyExport.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
     
-            return Header;
+            return TemporaryExposureKeyExport;
         })();
     
-        covidshield.Key = (function() {
+        covidshield.SignatureInfo = (function() {
     
             /**
-             * Properties of a Key.
+             * Properties of a SignatureInfo.
              * @memberof covidshield
-             * @interface IKey
-             * @property {Uint8Array|null} [keyData] Key keyData
-             * @property {number|null} [rollingStartNumber] Key rollingStartNumber
-             * @property {number|null} [rollingPeriod] Key rollingPeriod
-             * @property {number|null} [transmissionRiskLevel] Key transmissionRiskLevel
+             * @interface ISignatureInfo
+             * @property {string|null} [verificationKeyVersion] SignatureInfo verificationKeyVersion
+             * @property {string|null} [verificationKeyId] SignatureInfo verificationKeyId
+             * @property {string|null} [signatureAlgorithm] SignatureInfo signatureAlgorithm
              */
     
             /**
-             * Constructs a new Key.
+             * Constructs a new SignatureInfo.
              * @memberof covidshield
-             * @classdesc Represents a Key.
-             * @implements IKey
+             * @classdesc Represents a SignatureInfo.
+             * @implements ISignatureInfo
              * @constructor
-             * @param {covidshield.IKey=} [properties] Properties to set
+             * @param {covidshield.ISignatureInfo=} [properties] Properties to set
              */
-            function Key(properties) {
+            function SignatureInfo(properties) {
                 if (properties)
                     for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                         if (properties[keys[i]] != null)
@@ -1897,114 +1811,101 @@
             }
     
             /**
-             * Key keyData.
-             * @member {Uint8Array} keyData
-             * @memberof covidshield.Key
+             * SignatureInfo verificationKeyVersion.
+             * @member {string} verificationKeyVersion
+             * @memberof covidshield.SignatureInfo
              * @instance
              */
-            Key.prototype.keyData = $util.newBuffer([]);
+            SignatureInfo.prototype.verificationKeyVersion = "";
     
             /**
-             * Key rollingStartNumber.
-             * @member {number} rollingStartNumber
-             * @memberof covidshield.Key
+             * SignatureInfo verificationKeyId.
+             * @member {string} verificationKeyId
+             * @memberof covidshield.SignatureInfo
              * @instance
              */
-            Key.prototype.rollingStartNumber = 0;
+            SignatureInfo.prototype.verificationKeyId = "";
     
             /**
-             * Key rollingPeriod.
-             * @member {number} rollingPeriod
-             * @memberof covidshield.Key
+             * SignatureInfo signatureAlgorithm.
+             * @member {string} signatureAlgorithm
+             * @memberof covidshield.SignatureInfo
              * @instance
              */
-            Key.prototype.rollingPeriod = 0;
+            SignatureInfo.prototype.signatureAlgorithm = "";
     
             /**
-             * Key transmissionRiskLevel.
-             * @member {number} transmissionRiskLevel
-             * @memberof covidshield.Key
-             * @instance
-             */
-            Key.prototype.transmissionRiskLevel = 0;
-    
-            /**
-             * Creates a new Key instance using the specified properties.
+             * Creates a new SignatureInfo instance using the specified properties.
              * @function create
-             * @memberof covidshield.Key
+             * @memberof covidshield.SignatureInfo
              * @static
-             * @param {covidshield.IKey=} [properties] Properties to set
-             * @returns {covidshield.Key} Key instance
+             * @param {covidshield.ISignatureInfo=} [properties] Properties to set
+             * @returns {covidshield.SignatureInfo} SignatureInfo instance
              */
-            Key.create = function create(properties) {
-                return new Key(properties);
+            SignatureInfo.create = function create(properties) {
+                return new SignatureInfo(properties);
             };
     
             /**
-             * Encodes the specified Key message. Does not implicitly {@link covidshield.Key.verify|verify} messages.
+             * Encodes the specified SignatureInfo message. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
              * @function encode
-             * @memberof covidshield.Key
+             * @memberof covidshield.SignatureInfo
              * @static
-             * @param {covidshield.IKey} message Key message or plain object to encode
+             * @param {covidshield.ISignatureInfo} message SignatureInfo message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Key.encode = function encode(message, writer) {
+            SignatureInfo.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.keyData != null && Object.hasOwnProperty.call(message, "keyData"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.keyData);
-                if (message.rollingStartNumber != null && Object.hasOwnProperty.call(message, "rollingStartNumber"))
-                    writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.rollingStartNumber);
-                if (message.rollingPeriod != null && Object.hasOwnProperty.call(message, "rollingPeriod"))
-                    writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.rollingPeriod);
-                if (message.transmissionRiskLevel != null && Object.hasOwnProperty.call(message, "transmissionRiskLevel"))
-                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.transmissionRiskLevel);
+                if (message.verificationKeyVersion != null && Object.hasOwnProperty.call(message, "verificationKeyVersion"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.verificationKeyVersion);
+                if (message.verificationKeyId != null && Object.hasOwnProperty.call(message, "verificationKeyId"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.verificationKeyId);
+                if (message.signatureAlgorithm != null && Object.hasOwnProperty.call(message, "signatureAlgorithm"))
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.signatureAlgorithm);
                 return writer;
             };
     
             /**
-             * Encodes the specified Key message, length delimited. Does not implicitly {@link covidshield.Key.verify|verify} messages.
+             * Encodes the specified SignatureInfo message, length delimited. Does not implicitly {@link covidshield.SignatureInfo.verify|verify} messages.
              * @function encodeDelimited
-             * @memberof covidshield.Key
+             * @memberof covidshield.SignatureInfo
              * @static
-             * @param {covidshield.IKey} message Key message or plain object to encode
+             * @param {covidshield.ISignatureInfo} message SignatureInfo message or plain object to encode
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Key.encodeDelimited = function encodeDelimited(message, writer) {
+            SignatureInfo.encodeDelimited = function encodeDelimited(message, writer) {
                 return this.encode(message, writer).ldelim();
             };
     
             /**
-             * Decodes a Key message from the specified reader or buffer.
+             * Decodes a SignatureInfo message from the specified reader or buffer.
              * @function decode
-             * @memberof covidshield.Key
+             * @memberof covidshield.SignatureInfo
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
              * @param {number} [length] Message length if known beforehand
-             * @returns {covidshield.Key} Key
+             * @returns {covidshield.SignatureInfo} SignatureInfo
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Key.decode = function decode(reader, length) {
+            SignatureInfo.decode = function decode(reader, length) {
                 if (!(reader instanceof $Reader))
                     reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.Key();
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.SignatureInfo();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.keyData = reader.bytes();
-                        break;
-                    case 2:
-                        message.rollingStartNumber = reader.uint32();
-                        break;
                     case 3:
-                        message.rollingPeriod = reader.uint32();
+                        message.verificationKeyVersion = reader.string();
                         break;
                     case 4:
-                        message.transmissionRiskLevel = reader.int32();
+                        message.verificationKeyId = reader.string();
+                        break;
+                    case 5:
+                        message.signatureAlgorithm = reader.string();
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -2015,83 +1916,329 @@
             };
     
             /**
-             * Decodes a Key message from the specified reader or buffer, length delimited.
+             * Decodes a SignatureInfo message from the specified reader or buffer, length delimited.
              * @function decodeDelimited
-             * @memberof covidshield.Key
+             * @memberof covidshield.SignatureInfo
              * @static
              * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {covidshield.Key} Key
+             * @returns {covidshield.SignatureInfo} SignatureInfo
              * @throws {Error} If the payload is not a reader or valid buffer
              * @throws {$protobuf.util.ProtocolError} If required fields are missing
              */
-            Key.decodeDelimited = function decodeDelimited(reader) {
+            SignatureInfo.decodeDelimited = function decodeDelimited(reader) {
                 if (!(reader instanceof $Reader))
                     reader = new $Reader(reader);
                 return this.decode(reader, reader.uint32());
             };
     
             /**
-             * Verifies a Key message.
+             * Verifies a SignatureInfo message.
              * @function verify
-             * @memberof covidshield.Key
+             * @memberof covidshield.SignatureInfo
              * @static
              * @param {Object.<string,*>} message Plain object to verify
              * @returns {string|null} `null` if valid, otherwise the reason why it is not
              */
-            Key.verify = function verify(message) {
+            SignatureInfo.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.verificationKeyVersion != null && message.hasOwnProperty("verificationKeyVersion"))
+                    if (!$util.isString(message.verificationKeyVersion))
+                        return "verificationKeyVersion: string expected";
+                if (message.verificationKeyId != null && message.hasOwnProperty("verificationKeyId"))
+                    if (!$util.isString(message.verificationKeyId))
+                        return "verificationKeyId: string expected";
+                if (message.signatureAlgorithm != null && message.hasOwnProperty("signatureAlgorithm"))
+                    if (!$util.isString(message.signatureAlgorithm))
+                        return "signatureAlgorithm: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a SignatureInfo message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof covidshield.SignatureInfo
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {covidshield.SignatureInfo} SignatureInfo
+             */
+            SignatureInfo.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.SignatureInfo)
+                    return object;
+                var message = new $root.covidshield.SignatureInfo();
+                if (object.verificationKeyVersion != null)
+                    message.verificationKeyVersion = String(object.verificationKeyVersion);
+                if (object.verificationKeyId != null)
+                    message.verificationKeyId = String(object.verificationKeyId);
+                if (object.signatureAlgorithm != null)
+                    message.signatureAlgorithm = String(object.signatureAlgorithm);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a SignatureInfo message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof covidshield.SignatureInfo
+             * @static
+             * @param {covidshield.SignatureInfo} message SignatureInfo
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            SignatureInfo.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.verificationKeyVersion = "";
+                    object.verificationKeyId = "";
+                    object.signatureAlgorithm = "";
+                }
+                if (message.verificationKeyVersion != null && message.hasOwnProperty("verificationKeyVersion"))
+                    object.verificationKeyVersion = message.verificationKeyVersion;
+                if (message.verificationKeyId != null && message.hasOwnProperty("verificationKeyId"))
+                    object.verificationKeyId = message.verificationKeyId;
+                if (message.signatureAlgorithm != null && message.hasOwnProperty("signatureAlgorithm"))
+                    object.signatureAlgorithm = message.signatureAlgorithm;
+                return object;
+            };
+    
+            /**
+             * Converts this SignatureInfo to JSON.
+             * @function toJSON
+             * @memberof covidshield.SignatureInfo
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            SignatureInfo.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return SignatureInfo;
+        })();
+    
+        covidshield.TemporaryExposureKey = (function() {
+    
+            /**
+             * Properties of a TemporaryExposureKey.
+             * @memberof covidshield
+             * @interface ITemporaryExposureKey
+             * @property {Uint8Array|null} [keyData] TemporaryExposureKey keyData
+             * @property {number|null} [transmissionRiskLevel] TemporaryExposureKey transmissionRiskLevel
+             * @property {number|null} [rollingStartIntervalNumber] TemporaryExposureKey rollingStartIntervalNumber
+             * @property {number|null} [rollingPeriod] TemporaryExposureKey rollingPeriod
+             */
+    
+            /**
+             * Constructs a new TemporaryExposureKey.
+             * @memberof covidshield
+             * @classdesc Represents a TemporaryExposureKey.
+             * @implements ITemporaryExposureKey
+             * @constructor
+             * @param {covidshield.ITemporaryExposureKey=} [properties] Properties to set
+             */
+            function TemporaryExposureKey(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * TemporaryExposureKey keyData.
+             * @member {Uint8Array} keyData
+             * @memberof covidshield.TemporaryExposureKey
+             * @instance
+             */
+            TemporaryExposureKey.prototype.keyData = $util.newBuffer([]);
+    
+            /**
+             * TemporaryExposureKey transmissionRiskLevel.
+             * @member {number} transmissionRiskLevel
+             * @memberof covidshield.TemporaryExposureKey
+             * @instance
+             */
+            TemporaryExposureKey.prototype.transmissionRiskLevel = 0;
+    
+            /**
+             * TemporaryExposureKey rollingStartIntervalNumber.
+             * @member {number} rollingStartIntervalNumber
+             * @memberof covidshield.TemporaryExposureKey
+             * @instance
+             */
+            TemporaryExposureKey.prototype.rollingStartIntervalNumber = 0;
+    
+            /**
+             * TemporaryExposureKey rollingPeriod.
+             * @member {number} rollingPeriod
+             * @memberof covidshield.TemporaryExposureKey
+             * @instance
+             */
+            TemporaryExposureKey.prototype.rollingPeriod = 144;
+    
+            /**
+             * Creates a new TemporaryExposureKey instance using the specified properties.
+             * @function create
+             * @memberof covidshield.TemporaryExposureKey
+             * @static
+             * @param {covidshield.ITemporaryExposureKey=} [properties] Properties to set
+             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey instance
+             */
+            TemporaryExposureKey.create = function create(properties) {
+                return new TemporaryExposureKey(properties);
+            };
+    
+            /**
+             * Encodes the specified TemporaryExposureKey message. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
+             * @function encode
+             * @memberof covidshield.TemporaryExposureKey
+             * @static
+             * @param {covidshield.ITemporaryExposureKey} message TemporaryExposureKey message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            TemporaryExposureKey.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.keyData != null && Object.hasOwnProperty.call(message, "keyData"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.keyData);
+                if (message.transmissionRiskLevel != null && Object.hasOwnProperty.call(message, "transmissionRiskLevel"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.transmissionRiskLevel);
+                if (message.rollingStartIntervalNumber != null && Object.hasOwnProperty.call(message, "rollingStartIntervalNumber"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.rollingStartIntervalNumber);
+                if (message.rollingPeriod != null && Object.hasOwnProperty.call(message, "rollingPeriod"))
+                    writer.uint32(/* id 4, wireType 0 =*/32).int32(message.rollingPeriod);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified TemporaryExposureKey message, length delimited. Does not implicitly {@link covidshield.TemporaryExposureKey.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof covidshield.TemporaryExposureKey
+             * @static
+             * @param {covidshield.ITemporaryExposureKey} message TemporaryExposureKey message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            TemporaryExposureKey.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a TemporaryExposureKey message from the specified reader or buffer.
+             * @function decode
+             * @memberof covidshield.TemporaryExposureKey
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            TemporaryExposureKey.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TemporaryExposureKey();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.keyData = reader.bytes();
+                        break;
+                    case 2:
+                        message.transmissionRiskLevel = reader.int32();
+                        break;
+                    case 3:
+                        message.rollingStartIntervalNumber = reader.int32();
+                        break;
+                    case 4:
+                        message.rollingPeriod = reader.int32();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a TemporaryExposureKey message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof covidshield.TemporaryExposureKey
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            TemporaryExposureKey.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a TemporaryExposureKey message.
+             * @function verify
+             * @memberof covidshield.TemporaryExposureKey
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            TemporaryExposureKey.verify = function verify(message) {
                 if (typeof message !== "object" || message === null)
                     return "object expected";
                 if (message.keyData != null && message.hasOwnProperty("keyData"))
                     if (!(message.keyData && typeof message.keyData.length === "number" || $util.isString(message.keyData)))
                         return "keyData: buffer expected";
-                if (message.rollingStartNumber != null && message.hasOwnProperty("rollingStartNumber"))
-                    if (!$util.isInteger(message.rollingStartNumber))
-                        return "rollingStartNumber: integer expected";
-                if (message.rollingPeriod != null && message.hasOwnProperty("rollingPeriod"))
-                    if (!$util.isInteger(message.rollingPeriod))
-                        return "rollingPeriod: integer expected";
                 if (message.transmissionRiskLevel != null && message.hasOwnProperty("transmissionRiskLevel"))
                     if (!$util.isInteger(message.transmissionRiskLevel))
                         return "transmissionRiskLevel: integer expected";
+                if (message.rollingStartIntervalNumber != null && message.hasOwnProperty("rollingStartIntervalNumber"))
+                    if (!$util.isInteger(message.rollingStartIntervalNumber))
+                        return "rollingStartIntervalNumber: integer expected";
+                if (message.rollingPeriod != null && message.hasOwnProperty("rollingPeriod"))
+                    if (!$util.isInteger(message.rollingPeriod))
+                        return "rollingPeriod: integer expected";
                 return null;
             };
     
             /**
-             * Creates a Key message from a plain object. Also converts values to their respective internal types.
+             * Creates a TemporaryExposureKey message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
-             * @memberof covidshield.Key
+             * @memberof covidshield.TemporaryExposureKey
              * @static
              * @param {Object.<string,*>} object Plain object
-             * @returns {covidshield.Key} Key
+             * @returns {covidshield.TemporaryExposureKey} TemporaryExposureKey
              */
-            Key.fromObject = function fromObject(object) {
-                if (object instanceof $root.covidshield.Key)
+            TemporaryExposureKey.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.TemporaryExposureKey)
                     return object;
-                var message = new $root.covidshield.Key();
+                var message = new $root.covidshield.TemporaryExposureKey();
                 if (object.keyData != null)
                     if (typeof object.keyData === "string")
                         $util.base64.decode(object.keyData, message.keyData = $util.newBuffer($util.base64.length(object.keyData)), 0);
                     else if (object.keyData.length)
                         message.keyData = object.keyData;
-                if (object.rollingStartNumber != null)
-                    message.rollingStartNumber = object.rollingStartNumber >>> 0;
-                if (object.rollingPeriod != null)
-                    message.rollingPeriod = object.rollingPeriod >>> 0;
                 if (object.transmissionRiskLevel != null)
                     message.transmissionRiskLevel = object.transmissionRiskLevel | 0;
+                if (object.rollingStartIntervalNumber != null)
+                    message.rollingStartIntervalNumber = object.rollingStartIntervalNumber | 0;
+                if (object.rollingPeriod != null)
+                    message.rollingPeriod = object.rollingPeriod | 0;
                 return message;
             };
     
             /**
-             * Creates a plain object from a Key message. Also converts values to other types if specified.
+             * Creates a plain object from a TemporaryExposureKey message. Also converts values to other types if specified.
              * @function toObject
-             * @memberof covidshield.Key
+             * @memberof covidshield.TemporaryExposureKey
              * @static
-             * @param {covidshield.Key} message Key
+             * @param {covidshield.TemporaryExposureKey} message TemporaryExposureKey
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Key.toObject = function toObject(message, options) {
+            TemporaryExposureKey.toObject = function toObject(message, options) {
                 if (!options)
                     options = {};
                 var object = {};
@@ -2103,33 +2250,509 @@
                         if (options.bytes !== Array)
                             object.keyData = $util.newBuffer(object.keyData);
                     }
-                    object.rollingStartNumber = 0;
-                    object.rollingPeriod = 0;
                     object.transmissionRiskLevel = 0;
+                    object.rollingStartIntervalNumber = 0;
+                    object.rollingPeriod = 144;
                 }
                 if (message.keyData != null && message.hasOwnProperty("keyData"))
                     object.keyData = options.bytes === String ? $util.base64.encode(message.keyData, 0, message.keyData.length) : options.bytes === Array ? Array.prototype.slice.call(message.keyData) : message.keyData;
-                if (message.rollingStartNumber != null && message.hasOwnProperty("rollingStartNumber"))
-                    object.rollingStartNumber = message.rollingStartNumber;
-                if (message.rollingPeriod != null && message.hasOwnProperty("rollingPeriod"))
-                    object.rollingPeriod = message.rollingPeriod;
                 if (message.transmissionRiskLevel != null && message.hasOwnProperty("transmissionRiskLevel"))
                     object.transmissionRiskLevel = message.transmissionRiskLevel;
+                if (message.rollingStartIntervalNumber != null && message.hasOwnProperty("rollingStartIntervalNumber"))
+                    object.rollingStartIntervalNumber = message.rollingStartIntervalNumber;
+                if (message.rollingPeriod != null && message.hasOwnProperty("rollingPeriod"))
+                    object.rollingPeriod = message.rollingPeriod;
                 return object;
             };
     
             /**
-             * Converts this Key to JSON.
+             * Converts this TemporaryExposureKey to JSON.
              * @function toJSON
-             * @memberof covidshield.Key
+             * @memberof covidshield.TemporaryExposureKey
              * @instance
              * @returns {Object.<string,*>} JSON object
              */
-            Key.prototype.toJSON = function toJSON() {
+            TemporaryExposureKey.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
     
-            return Key;
+            return TemporaryExposureKey;
+        })();
+    
+        covidshield.TEKSignatureList = (function() {
+    
+            /**
+             * Properties of a TEKSignatureList.
+             * @memberof covidshield
+             * @interface ITEKSignatureList
+             * @property {Array.<covidshield.ITEKSignature>|null} [signatures] TEKSignatureList signatures
+             */
+    
+            /**
+             * Constructs a new TEKSignatureList.
+             * @memberof covidshield
+             * @classdesc Represents a TEKSignatureList.
+             * @implements ITEKSignatureList
+             * @constructor
+             * @param {covidshield.ITEKSignatureList=} [properties] Properties to set
+             */
+            function TEKSignatureList(properties) {
+                this.signatures = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * TEKSignatureList signatures.
+             * @member {Array.<covidshield.ITEKSignature>} signatures
+             * @memberof covidshield.TEKSignatureList
+             * @instance
+             */
+            TEKSignatureList.prototype.signatures = $util.emptyArray;
+    
+            /**
+             * Creates a new TEKSignatureList instance using the specified properties.
+             * @function create
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {covidshield.ITEKSignatureList=} [properties] Properties to set
+             * @returns {covidshield.TEKSignatureList} TEKSignatureList instance
+             */
+            TEKSignatureList.create = function create(properties) {
+                return new TEKSignatureList(properties);
+            };
+    
+            /**
+             * Encodes the specified TEKSignatureList message. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
+             * @function encode
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {covidshield.ITEKSignatureList} message TEKSignatureList message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            TEKSignatureList.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.signatures != null && message.signatures.length)
+                    for (var i = 0; i < message.signatures.length; ++i)
+                        $root.covidshield.TEKSignature.encode(message.signatures[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified TEKSignatureList message, length delimited. Does not implicitly {@link covidshield.TEKSignatureList.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {covidshield.ITEKSignatureList} message TEKSignatureList message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            TEKSignatureList.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a TEKSignatureList message from the specified reader or buffer.
+             * @function decode
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {covidshield.TEKSignatureList} TEKSignatureList
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            TEKSignatureList.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TEKSignatureList();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.signatures && message.signatures.length))
+                            message.signatures = [];
+                        message.signatures.push($root.covidshield.TEKSignature.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a TEKSignatureList message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {covidshield.TEKSignatureList} TEKSignatureList
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            TEKSignatureList.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a TEKSignatureList message.
+             * @function verify
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            TEKSignatureList.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.signatures != null && message.hasOwnProperty("signatures")) {
+                    if (!Array.isArray(message.signatures))
+                        return "signatures: array expected";
+                    for (var i = 0; i < message.signatures.length; ++i) {
+                        var error = $root.covidshield.TEKSignature.verify(message.signatures[i]);
+                        if (error)
+                            return "signatures." + error;
+                    }
+                }
+                return null;
+            };
+    
+            /**
+             * Creates a TEKSignatureList message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {covidshield.TEKSignatureList} TEKSignatureList
+             */
+            TEKSignatureList.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.TEKSignatureList)
+                    return object;
+                var message = new $root.covidshield.TEKSignatureList();
+                if (object.signatures) {
+                    if (!Array.isArray(object.signatures))
+                        throw TypeError(".covidshield.TEKSignatureList.signatures: array expected");
+                    message.signatures = [];
+                    for (var i = 0; i < object.signatures.length; ++i) {
+                        if (typeof object.signatures[i] !== "object")
+                            throw TypeError(".covidshield.TEKSignatureList.signatures: object expected");
+                        message.signatures[i] = $root.covidshield.TEKSignature.fromObject(object.signatures[i]);
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a TEKSignatureList message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof covidshield.TEKSignatureList
+             * @static
+             * @param {covidshield.TEKSignatureList} message TEKSignatureList
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            TEKSignatureList.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.signatures = [];
+                if (message.signatures && message.signatures.length) {
+                    object.signatures = [];
+                    for (var j = 0; j < message.signatures.length; ++j)
+                        object.signatures[j] = $root.covidshield.TEKSignature.toObject(message.signatures[j], options);
+                }
+                return object;
+            };
+    
+            /**
+             * Converts this TEKSignatureList to JSON.
+             * @function toJSON
+             * @memberof covidshield.TEKSignatureList
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            TEKSignatureList.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return TEKSignatureList;
+        })();
+    
+        covidshield.TEKSignature = (function() {
+    
+            /**
+             * Properties of a TEKSignature.
+             * @memberof covidshield
+             * @interface ITEKSignature
+             * @property {covidshield.ISignatureInfo|null} [signatureInfo] TEKSignature signatureInfo
+             * @property {number|null} [batchNum] TEKSignature batchNum
+             * @property {number|null} [batchSize] TEKSignature batchSize
+             * @property {Uint8Array|null} [signature] TEKSignature signature
+             */
+    
+            /**
+             * Constructs a new TEKSignature.
+             * @memberof covidshield
+             * @classdesc Represents a TEKSignature.
+             * @implements ITEKSignature
+             * @constructor
+             * @param {covidshield.ITEKSignature=} [properties] Properties to set
+             */
+            function TEKSignature(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * TEKSignature signatureInfo.
+             * @member {covidshield.ISignatureInfo|null|undefined} signatureInfo
+             * @memberof covidshield.TEKSignature
+             * @instance
+             */
+            TEKSignature.prototype.signatureInfo = null;
+    
+            /**
+             * TEKSignature batchNum.
+             * @member {number} batchNum
+             * @memberof covidshield.TEKSignature
+             * @instance
+             */
+            TEKSignature.prototype.batchNum = 0;
+    
+            /**
+             * TEKSignature batchSize.
+             * @member {number} batchSize
+             * @memberof covidshield.TEKSignature
+             * @instance
+             */
+            TEKSignature.prototype.batchSize = 0;
+    
+            /**
+             * TEKSignature signature.
+             * @member {Uint8Array} signature
+             * @memberof covidshield.TEKSignature
+             * @instance
+             */
+            TEKSignature.prototype.signature = $util.newBuffer([]);
+    
+            /**
+             * Creates a new TEKSignature instance using the specified properties.
+             * @function create
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {covidshield.ITEKSignature=} [properties] Properties to set
+             * @returns {covidshield.TEKSignature} TEKSignature instance
+             */
+            TEKSignature.create = function create(properties) {
+                return new TEKSignature(properties);
+            };
+    
+            /**
+             * Encodes the specified TEKSignature message. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
+             * @function encode
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {covidshield.ITEKSignature} message TEKSignature message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            TEKSignature.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.signatureInfo != null && Object.hasOwnProperty.call(message, "signatureInfo"))
+                    $root.covidshield.SignatureInfo.encode(message.signatureInfo, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.batchNum != null && Object.hasOwnProperty.call(message, "batchNum"))
+                    writer.uint32(/* id 2, wireType 0 =*/16).int32(message.batchNum);
+                if (message.batchSize != null && Object.hasOwnProperty.call(message, "batchSize"))
+                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.batchSize);
+                if (message.signature != null && Object.hasOwnProperty.call(message, "signature"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.signature);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified TEKSignature message, length delimited. Does not implicitly {@link covidshield.TEKSignature.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {covidshield.ITEKSignature} message TEKSignature message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            TEKSignature.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a TEKSignature message from the specified reader or buffer.
+             * @function decode
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {covidshield.TEKSignature} TEKSignature
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            TEKSignature.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.covidshield.TEKSignature();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.signatureInfo = $root.covidshield.SignatureInfo.decode(reader, reader.uint32());
+                        break;
+                    case 2:
+                        message.batchNum = reader.int32();
+                        break;
+                    case 3:
+                        message.batchSize = reader.int32();
+                        break;
+                    case 4:
+                        message.signature = reader.bytes();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a TEKSignature message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {covidshield.TEKSignature} TEKSignature
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            TEKSignature.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a TEKSignature message.
+             * @function verify
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            TEKSignature.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.signatureInfo != null && message.hasOwnProperty("signatureInfo")) {
+                    var error = $root.covidshield.SignatureInfo.verify(message.signatureInfo);
+                    if (error)
+                        return "signatureInfo." + error;
+                }
+                if (message.batchNum != null && message.hasOwnProperty("batchNum"))
+                    if (!$util.isInteger(message.batchNum))
+                        return "batchNum: integer expected";
+                if (message.batchSize != null && message.hasOwnProperty("batchSize"))
+                    if (!$util.isInteger(message.batchSize))
+                        return "batchSize: integer expected";
+                if (message.signature != null && message.hasOwnProperty("signature"))
+                    if (!(message.signature && typeof message.signature.length === "number" || $util.isString(message.signature)))
+                        return "signature: buffer expected";
+                return null;
+            };
+    
+            /**
+             * Creates a TEKSignature message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {covidshield.TEKSignature} TEKSignature
+             */
+            TEKSignature.fromObject = function fromObject(object) {
+                if (object instanceof $root.covidshield.TEKSignature)
+                    return object;
+                var message = new $root.covidshield.TEKSignature();
+                if (object.signatureInfo != null) {
+                    if (typeof object.signatureInfo !== "object")
+                        throw TypeError(".covidshield.TEKSignature.signatureInfo: object expected");
+                    message.signatureInfo = $root.covidshield.SignatureInfo.fromObject(object.signatureInfo);
+                }
+                if (object.batchNum != null)
+                    message.batchNum = object.batchNum | 0;
+                if (object.batchSize != null)
+                    message.batchSize = object.batchSize | 0;
+                if (object.signature != null)
+                    if (typeof object.signature === "string")
+                        $util.base64.decode(object.signature, message.signature = $util.newBuffer($util.base64.length(object.signature)), 0);
+                    else if (object.signature.length)
+                        message.signature = object.signature;
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a TEKSignature message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof covidshield.TEKSignature
+             * @static
+             * @param {covidshield.TEKSignature} message TEKSignature
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            TEKSignature.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.signatureInfo = null;
+                    object.batchNum = 0;
+                    object.batchSize = 0;
+                    if (options.bytes === String)
+                        object.signature = "";
+                    else {
+                        object.signature = [];
+                        if (options.bytes !== Array)
+                            object.signature = $util.newBuffer(object.signature);
+                    }
+                }
+                if (message.signatureInfo != null && message.hasOwnProperty("signatureInfo"))
+                    object.signatureInfo = $root.covidshield.SignatureInfo.toObject(message.signatureInfo, options);
+                if (message.batchNum != null && message.hasOwnProperty("batchNum"))
+                    object.batchNum = message.batchNum;
+                if (message.batchSize != null && message.hasOwnProperty("batchSize"))
+                    object.batchSize = message.batchSize;
+                if (message.signature != null && message.hasOwnProperty("signature"))
+                    object.signature = options.bytes === String ? $util.base64.encode(message.signature, 0, message.signature.length) : options.bytes === Array ? Array.prototype.slice.call(message.signature) : message.signature;
+                return object;
+            };
+    
+            /**
+             * Converts this TEKSignature to JSON.
+             * @function toJSON
+             * @memberof covidshield.TEKSignature
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            TEKSignature.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return TEKSignature;
         })();
     
         return covidshield;
@@ -2375,6 +2998,230 @@
                 };
     
                 return Timestamp;
+            })();
+    
+            protobuf.Duration = (function() {
+    
+                /**
+                 * Properties of a Duration.
+                 * @memberof google.protobuf
+                 * @interface IDuration
+                 * @property {number|Long|null} [seconds] Duration seconds
+                 * @property {number|null} [nanos] Duration nanos
+                 */
+    
+                /**
+                 * Constructs a new Duration.
+                 * @memberof google.protobuf
+                 * @classdesc Represents a Duration.
+                 * @implements IDuration
+                 * @constructor
+                 * @param {google.protobuf.IDuration=} [properties] Properties to set
+                 */
+                function Duration(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+    
+                /**
+                 * Duration seconds.
+                 * @member {number|Long} seconds
+                 * @memberof google.protobuf.Duration
+                 * @instance
+                 */
+                Duration.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+    
+                /**
+                 * Duration nanos.
+                 * @member {number} nanos
+                 * @memberof google.protobuf.Duration
+                 * @instance
+                 */
+                Duration.prototype.nanos = 0;
+    
+                /**
+                 * Creates a new Duration instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {google.protobuf.IDuration=} [properties] Properties to set
+                 * @returns {google.protobuf.Duration} Duration instance
+                 */
+                Duration.create = function create(properties) {
+                    return new Duration(properties);
+                };
+    
+                /**
+                 * Encodes the specified Duration message. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {google.protobuf.IDuration} message Duration message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Duration.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.seconds != null && Object.hasOwnProperty.call(message, "seconds"))
+                        writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
+                    if (message.nanos != null && Object.hasOwnProperty.call(message, "nanos"))
+                        writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
+                    return writer;
+                };
+    
+                /**
+                 * Encodes the specified Duration message, length delimited. Does not implicitly {@link google.protobuf.Duration.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {google.protobuf.IDuration} message Duration message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Duration.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+    
+                /**
+                 * Decodes a Duration message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.Duration} Duration
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Duration.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Duration();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.seconds = reader.int64();
+                            break;
+                        case 2:
+                            message.nanos = reader.int32();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+    
+                /**
+                 * Decodes a Duration message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.Duration} Duration
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Duration.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+    
+                /**
+                 * Verifies a Duration message.
+                 * @function verify
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                Duration.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
+                        if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
+                            return "seconds: integer|Long expected";
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
+                        if (!$util.isInteger(message.nanos))
+                            return "nanos: integer expected";
+                    return null;
+                };
+    
+                /**
+                 * Creates a Duration message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.Duration} Duration
+                 */
+                Duration.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.Duration)
+                        return object;
+                    var message = new $root.google.protobuf.Duration();
+                    if (object.seconds != null)
+                        if ($util.Long)
+                            (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
+                        else if (typeof object.seconds === "string")
+                            message.seconds = parseInt(object.seconds, 10);
+                        else if (typeof object.seconds === "number")
+                            message.seconds = object.seconds;
+                        else if (typeof object.seconds === "object")
+                            message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
+                    if (object.nanos != null)
+                        message.nanos = object.nanos | 0;
+                    return message;
+                };
+    
+                /**
+                 * Creates a plain object from a Duration message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.Duration
+                 * @static
+                 * @param {google.protobuf.Duration} message Duration
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Duration.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults) {
+                        if ($util.Long) {
+                            var long = new $util.Long(0, 0, false);
+                            object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        } else
+                            object.seconds = options.longs === String ? "0" : 0;
+                        object.nanos = 0;
+                    }
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
+                        if (typeof message.seconds === "number")
+                            object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
+                        else
+                            object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
+                        object.nanos = message.nanos;
+                    return object;
+                };
+    
+                /**
+                 * Converts this Duration to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.Duration
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Duration.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+    
+                return Duration;
             })();
     
             return protobuf;

--- a/src/services/BackendService/covidshield/covidshield.proto
+++ b/src/services/BackendService/covidshield/covidshield.proto
@@ -1,28 +1,29 @@
 syntax = "proto2";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 package covidshield;
 option go_package="pkg/proto/covidshield";
 
 // Clients will receive a One Time Code via some external channel (i.e. SMS or
 // verbal). Then, upon issuing THIS request, they will generate a new keypair.
-// If the response comes back successful, the appPublicKey (and the
-// corresponding private key) and the returned serverPublicKey will be kept in
+// If the response comes back successful, the app_public_key (and the
+// corresponding private key) and the returned server_public_key will be kept in
 // local storage for the duration of this reporting window (the next 14 days).
 //
-// appPublicKeys must not be re-used for new KeyClaimRequests, or the requests
+// app_public_keys must not be re-used for new KeyClaimRequests, or the requests
 // will fail.
 message KeyClaimRequest {
-  // oneTimeCode is the code received from the testing portal.
-  required string oneTimeCode = 1; // 8 numerical digits
-  // appPublicKey is generated locally and saved upon successful request
+  // one_time_code is the code received from the testing portal.
+  required string one_time_code = 1; // 8 numerical digits
+  // app_public_key is generated locally and saved upon successful request
   // completion.
-  required bytes appPublicKey = 2; // 32 bytes
+  required bytes app_public_key = 2; // 32 bytes
 }
 
 // KeyClaimResponse is received from the server in response to a
 // KeyClaimRequest. If the request was successful, error will be NONE and
-// serverPublicKey will be set.
+// server_public_key will be set.
 message KeyClaimResponse {
   enum ErrorCode {
     NONE = 0;
@@ -31,9 +32,12 @@ message KeyClaimResponse {
     SERVER_ERROR = 3;
     // Indicates the key is invalid, or already registered.
     INVALID_KEY = 4;
+    TEMPORARY_BAN = 5;
   }
   optional ErrorCode error = 1;
-  optional bytes serverPublicKey = 2; // 32 bytes
+  optional bytes server_public_key = 2; // 32 bytes
+  optional uint32 tries_remaining = 3;
+  optional google.protobuf.Duration remaining_ban_duration = 4;
 }
 
 // We are using a NaCl Box (Curve25519+XSalsa20+Poly1305) to encrypt and
@@ -47,16 +51,16 @@ message KeyClaimResponse {
 //
 // See "Security Model" at https://nacl.cr.yp.to/box.html
 message EncryptedUploadRequest {
-  // serverPublicKey is provided by the Diagnosis Server to the App, and is
+  // server_public_key is provided by the Diagnosis Server to the App, and is
   // used to encrypt the payload. This key should be stored locally for 14
   // days, and used to submit the follow-up Diagnosis Key.
-  required bytes serverPublicKey = 1; // 32 bytes
-  // appPublicKey is the public side of a keypair generated once by the
-  // application and linked to the serverPublicKey. These are linked in the
-  // Diagnosis Server, so that only one appPublicKey is authorized to upload
-  // for a given serverPublicKey. If a new serverPublicKey is issued to an App
-  // (e.g. months later), a new appPublicKey should be generated.
-  required bytes appPublicKey = 2; // 32 bytes
+  required bytes server_public_key = 1; // 32 bytes
+  // app_public_key is the public side of a keypair generated once by the
+  // application and linked to the server_public_key. These are linked in the
+  // Diagnosis Server, so that only one app_public_key is authorized to upload
+  // for a given server_public_key. If a new server_public_key is issued to an App
+  // (e.g. months later), a new app_public_key should be generated.
+  required bytes app_public_key = 2; // 32 bytes
   // nonce must be 24 random bytes, and absolutely must NOT be re-used between
   // subsequent submissions of Diagnosis Keys. This nonce is passed to the
   // encryption library to generate the ciphertext.
@@ -84,8 +88,9 @@ message EncryptedUploadResponse {
     INVALID_TIMESTAMP = 8;
     INVALID_ROLLING_PERIOD = 10;
     INVALID_KEY_DATA = 11;
-    INVALID_ROLLING_START_NUMBER = 12;
+    INVALID_ROLLING_START_INTERVAL_NUMBER = 12;
     INVALID_TRANSMISSION_RISK_LEVEL = 13;
+    NO_KEYS_IN_PAYLOAD = 14;
   }
   required ErrorCode error = 1;
 }
@@ -95,35 +100,103 @@ message Upload {
   // timestamp is just the current device time at message generation.
   required google.protobuf.Timestamp timestamp = 1;
   // keys returns from the ExposureNotification API.
-  repeated Key keys = 2;
+  repeated TemporaryExposureKey keys = 2;
 }
 
-// File, Header, and Key messages imported from:
-// https://developer.apple.com/documentation/exposurenotification/enmanager/3586331-detectexposures
+// Remaining messages imported from:
+// https://developer.apple.com/documentation/exposurenotification/setting_up_an_exposure_notification_server
 //
-// The format of the /retrieve-* endpoints is a stream of serialized File
+// And also referencing:
+// https://developers.google.com/android/exposure-notifications/exposure-key-file-format
+//
+// The format of the /keys endpoints is a stream of serialized File
 // messages, each length-prefixed with a big-endian uint32. Clients should take
-// care to verify that the batchSize from the headers matches the total number
+// care to verify that the batch_size from the headers matches the total number
 // of records received.
 //
-// In general, we don't change or add field definitions below this point.
+// Note, as a special case, that if there are no keys at all in the requested
+// range, the total content of the response will be "\x00\x00\x00\x00"; that
+// is, a big-endian uint32 of zero.
+//
+// In general, these definitions are copied from the resources above, but some
+// of the documentation is clarified or merged.
 
-message File {
-  optional Header header = 1;
-  repeated Key key = 2;
+message TemporaryExposureKeyExport {
+  // Time window of keys in the file, based on arrival
+  // at the server, in UTC seconds.
+  optional fixed64 start_timestamp = 1;
+  optional fixed64 end_timestamp = 2;
+
+  // Region from which these keys came (for example, MCC, however, some schemes
+  // use e.g. ISO-3166-2. There's no apparent hard requirement by the protocol
+  // for the contents here).
+  optional string region = 3;
+
+  // Reserved for future use. Both batch_num and batch_size
+  // must be set to a value of 1.
+  optional int32 batch_num = 4;
+  optional int32 batch_size = 5;
+
+  // Information about associated signatures.
+  repeated SignatureInfo signature_infos = 6;
+
+  // The temporary exposure keys themselves.
+  repeated TemporaryExposureKey keys = 7;
 }
 
-message Header {
-  optional int64 startTimestamp = 1; // Time window of keys in this file based on arrival to server, in UTC.
-  optional int64 endTimestamp = 2;
-  optional string region = 3; // Region for which these keys came from (e.g., country)
-  optional int32 batchNum = 4; // E.g., if batchNum=2;batchSize=10, this is batch 2 of 10
-  optional int32 batchSize = 5;
+message SignatureInfo {
+  // The first two fields have been deprecated
+  reserved 1, 2;
+  reserved "app_bundle_id", "android_package";
+
+  // Key version in case the EN server signing key is rotated.
+  optional string verification_key_version = 3;
+
+  // Additional information to uniquely identify the public key associated with
+  // the EN server's signing key (for example, the EN server might serve the
+  // app from different countries with different keys).
+  //
+  // Three-digit mobile country code (MCC) for validating the key file.
+  // If a region has more than one MCC, the server can choose
+  // which MCC to use. This value does not have to match the client's MCC,
+  // but must correspond to one of the supported MCCs for its region.
+  optional string verification_key_id = 4;
+
+  // All keys must be signed using the SHA-256 with ECDSA algorithm.
+  // This field must contain the string "1.2.840.10045.4.3.2".
+  optional string signature_algorithm = 5;
 }
 
-message Key {
-  optional bytes keyData = 1; // Key of infected user
-  optional uint32 rollingStartNumber = 2; // Interval number when the key's EKRollingPeriod started.
-  optional uint32 rollingPeriod = 3; // Number of 10-minute windows between key rolling.
-  optional int32 transmissionRiskLevel = 4; // Risk of transmission associated with the person this key came from.
+message TemporaryExposureKey {
+  // Temporary exposure key.
+  optional bytes key_data = 1;
+
+  // Varying risk associated with a key depending on the diagnosis method.
+  optional int32 transmission_risk_level = 2;
+
+  // Number representing the beginning interval for temporary exposure
+  // key validity (ENIntervalNumber).
+  optional int32 rolling_start_interval_number = 3;
+
+  // Number of intervals in a period.
+  optional int32 rolling_period = 4 [default = 144];
+}
+
+message TEKSignatureList {
+  // Information about associated signatures.
+  repeated TEKSignature signatures = 1;
+}
+
+message TEKSignature {
+  // Information to uniquely identify the public key associated
+  // with the EN server's signing key.
+  optional SignatureInfo signature_info = 1;
+
+  // Reserved for future use. Both batch_num and batch_size
+  // must be set to a value of 1.
+  optional int32 batch_num = 2;
+  optional int32 batch_size = 3;
+
+  // Signature in X9.62 format (ASN.1 SEQUENCE of two INTEGER fields).
+  optional bytes signature = 4;
 }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -3,10 +3,6 @@ import {when} from 'jest-when';
 
 import {ExposureNotificationService} from './ExposureNotificationService';
 
-jest.mock('react-native-zip-archive', () => ({
-  unzip: jest.fn(),
-}));
-
 const server: any = {
   retrieveDiagnosisKeys: jest.fn().mockResolvedValue(null),
   getExposureConfiguration: jest.fn().mockResolvedValue({}),
@@ -48,7 +44,7 @@ describe('ExposureNotificationService', () => {
       .mockImplementation((args: any) => new OriginalDate(args));
 
     await service.updateExposureStatus();
-    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(56);
+    expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(14);
   });
 
   it('backfills the right amount of keys for current day', async () => {
@@ -63,13 +59,13 @@ describe('ExposureNotificationService', () => {
 
     server.retrieveDiagnosisKeys.mockClear();
 
-    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-19T05:10:00+0000').getTime());
+    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-18T05:10:00+0000').getTime());
 
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
 
     server.retrieveDiagnosisKeys.mockClear();
-    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-18T23:10:00+0000').getTime());
+    storage.getItem.mockResolvedValue(new OriginalDate('2020-05-17T23:10:00+0000').getTime());
 
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -7,7 +7,7 @@ export function hoursSinceEpoch(date: Date) {
 }
 
 export function periodSinceEpoch(date: Date, hoursPerPeriod: number) {
-  return Math.floor(date.getTime() / (1000 * 3600 * hoursPerPeriod)) * hoursPerPeriod;
+  return Math.floor(date.getTime() / (1000 * 3600 * hoursPerPeriod));
 }
 
 export function daysFromNow(date: Date) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7235,11 +7235,6 @@ react-native-svg@^12.1.0:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-zip-archive@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-zip-archive/-/react-native-zip-archive-5.0.2.tgz#cfa2aa8c97dd4ccb2dd8c99812ec7d9e20bf7549"
-  integrity sha512-s/dSQ+XDK1aPnZ2YH1abIAWLwfylU1WptnQ0HuPVO0tahQKGQpcEgj+UQXnzPnUFHwAlTfvV7PjVyZQukNvWjw==
-
 react-native@0.62.2:
   version "0.62.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.2.tgz#d831e11a3178705449142df19a70ac2ca16bad10"


### PR DESCRIPTION
This PR fixes retrieval flow on Android. 

Resolves https://github.com/CovidShield/server/issues/70

## How to test?
- Run server locally https://github.com/CovidShield/server
- Connect mobile to local server via ngrok by changing `.env` file. 
- Change APP_ID to `com.google.android.apps.exposurenotification`.
- Make sure your device / account has EN enable. 
- Make sure `By pass signature check` is ON or `Enable app signature check` is OFF in debug mode (see screenshots below).
- Open app on Android device. 
- In `Test menu`, press `Clear exposure history and run check`. 
- You might need to set a couple of console.log in `ExposureNotificationService#performExposureStatusUpdate` to verify that the file is sent to the framework properly.

## Result

- Setup: I have 2 android devices running EN.
- The 1st device is set as positive result. When submitting the keys, I see 3 keys. I think it is collected from previous tests. The keys are submitted successfully.
```
exposureKeys [{"keyData": "CD5+GiVYuPa/FWNZUF65eA==", "rollingPeriod": 144, "rollingStartNumber": 2653776, "transmissionRiskLevel": 0}, {"keyData": "C4EvSp7ruvAtscLbi4h4Pg==", "rollingPeriod": 144, "rollingStartNumber": 2653920, "transmissionRiskLevel": 0}, {"keyData": "1mjqONFb6RLD/LxSBhEZ3w==", "rollingPeriod": 144, "rollingStartNumber": 2654064, "transmissionRiskLevel": 0}, {"keyData": "WnowdkMsDG+Dx4WqmHG3lg==", "rollingPeriod": 144, "rollingStartNumber": 2654208, "transmissionRiskLevel": 0}]
```
- The 2nd device is forced to refetch the diagnostic keys. I changed the server to return keys today too. It made 14 requests but none of them matched. Below is result of 14 requests.

Not sure what to do next to be able to test it. 🤔 

![image](https://user-images.githubusercontent.com/5274722/85086007-8b1fe700-b1a7-11ea-927b-c8fdcd7305f8.png)

## Outstanding:
- I haven't found a way to test two devices locally in test mode yet.

<img src="https://user-images.githubusercontent.com/5274722/85052150-7111e480-b166-11ea-9e0a-d64f92a698d5.png" width="240" />

<img src="https://user-images.githubusercontent.com/5274722/85052155-72dba800-b166-11ea-81bb-6e50cb0a48cf.png" width="240" />

