### PR TITLE
Fix persisting region with wrong key

### DIFF
--- a/src/services/StorageService/StorageService.ts
+++ b/src/services/StorageService/StorageService.ts
@@ -34,7 +34,7 @@ export class StorageService {
   };
 
   setRegion = async (value: Region | undefined) => {
-    await AsyncStorage.setItem(Key.Locale, value ? value : '');
+    await AsyncStorage.setItem(Key.Region, value ? value : '');
     this.region.set(value);
   };
 


### PR DESCRIPTION
Selected region was being persisted to AsyncStorage with wrong key - update to use correct key. Think this went unnoticed since region isn't really used in app so far, and it is set prior to any locale changes.