### PR TITLE
Check if initial status is correct

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -82,7 +82,7 @@ const Content = () => {
       return exposureStatus.needsSubmission ? <DiagnosedShareView /> : <DiagnosedView />;
     case 'monitoring':
     default:
-      if (!network.isConnected) return <NetworkDisabledView />;
+      if (!network.isConnected && network.type !== 'unknown') return <NetworkDisabledView />;
       switch (systemStatus) {
         case SystemStatus.Disabled:
         case SystemStatus.Restricted:


### PR DESCRIPTION
Per https://github.com/react-native-community/react-native-netinfo/issues/295 
initial network status is wrongly `false` which causes screen flickering:

![RPReplay_Final1592884789](https://user-images.githubusercontent.com/354010/85359584-ab6fde80-b4e4-11ea-86c7-ecbf885f2856.gif)
