### PR TITLE
Fix system status initial state

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 APP_ID_IOS=app.covidshield
-APP_ID_ANDROID=com.google.android.apps.exposurenotification
+APP_ID_ANDROID=app.covidshield
 APP_VERSION_CODE=1
 APP_VERSION_NAME=1.0
 
-SUBMIT_URL=https://7b20533b92a2.ngrok.io
-RETRIEVE_URL=https://5f69b761a612.ngrok.io
+SUBMIT_URL=https://submission.covidshield.app
+RETRIEVE_URL=https://retrieval.covidshield.app
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 REGION=302
 

--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 APP_ID_IOS=app.covidshield
-APP_ID_ANDROID=app.covidshield
+APP_ID_ANDROID=com.google.android.apps.exposurenotification
 APP_VERSION_CODE=1
 APP_VERSION_NAME=1.0
 
-SUBMIT_URL=https://submission.covidshield.app
-RETRIEVE_URL=https://retrieval.covidshield.app
+SUBMIT_URL=https://7b20533b92a2.ngrok.io
+RETRIEVE_URL=https://5f69b761a612.ngrok.io
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 REGION=302
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'CovidShield'
+include ':react-native-system-setting'
+project(':react-native-system-setting').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-system-setting/android')
 include ':react-native-sensitive-info'
 project(':react-native-sensitive-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sensitive-info/android')
 include ':react-native-config'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -91,6 +91,8 @@ target 'CovidShield' do
 
   pod 'react-native-sensitive-info', :path => '../node_modules/react-native-sensitive-info'
 
+  pod 'RCTSystemSetting', :path => '../node_modules/react-native-system-setting'
+
   target 'CovidShieldTests' do
     inherit! :complete
     # Pods for testing

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-native-snap-carousel": "^3.9.0",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.0",
+    "react-native-system-setting": "^1.7.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.20",
     "tweetnacl": "^1.0.3",
     "yarn": "^1.22.4"

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -47,7 +47,7 @@ const useNotificationPermissionStatus = (): [string, () => void] => {
       });
   };
 
-  return [status === 'granted' ? status : 'denied', request];
+  return [status, request];
 };
 
 const Content = () => {
@@ -77,6 +77,44 @@ const Content = () => {
   }
 };
 
+const CollapsedContent = () => {
+  const [systemStatus] = useSystemStatus();
+  const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
+  const showNotificationWarning = notificationStatus === 'denied';
+
+  if (systemStatus === SystemStatus.Unknown) {
+    return null;
+  }
+
+  return (
+    <CollapsedOverlayView
+      status={systemStatus}
+      notificationWarning={showNotificationWarning}
+      turnNotificationsOn={turnNotificationsOn}
+    />
+  );
+};
+
+const BottomSheetContent = () => {
+  const [systemStatus] = useSystemStatus();
+  const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
+  const showNotificationWarning = notificationStatus !== 'granted';
+  const maxWidth = useMaxContentWidth();
+
+  if (systemStatus === SystemStatus.Unknown) {
+    return null;
+  }
+
+  return (
+    <OverlayView
+      status={systemStatus}
+      notificationWarning={showNotificationWarning}
+      turnNotificationsOn={turnNotificationsOn}
+      maxWidth={maxWidth}
+    />
+  );
+};
+
 export const HomeScreen = () => {
   const navigation = useNavigation();
   useEffect(() => {
@@ -99,20 +137,10 @@ export const HomeScreen = () => {
     startExposureNotificationService();
   }, [startExposureNotificationService]);
 
-  const [systemStatus] = useSystemStatus();
-  const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
-  const showNotificationWarning = notificationStatus === 'denied';
-  const collapsedContent = useMemo(
-    () => (
-      <CollapsedOverlayView
-        status={systemStatus}
-        notificationWarning={showNotificationWarning}
-        turnNotificationsOn={turnNotificationsOn}
-      />
-    ),
-    [showNotificationWarning, systemStatus, turnNotificationsOn],
-  );
+  const collapsedContent = useMemo(() => <CollapsedContent />, []);
 
+  const [notificationStatus] = useNotificationPermissionStatus();
+  const showNotificationWarning = notificationStatus !== 'granted';
   const maxWidth = useMaxContentWidth();
 
   return (
@@ -126,12 +154,7 @@ export const HomeScreen = () => {
         collapsedContent={collapsedContent}
         extraContent={showNotificationWarning}
       >
-        <OverlayView
-          status={systemStatus}
-          notificationWarning={showNotificationWarning}
-          turnNotificationsOn={turnNotificationsOn}
-          maxWidth={maxWidth}
-        />
+        <BottomSheetContent />
       </BottomSheet>
     </Box>
   );

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -6,7 +6,7 @@ import {DevSettings} from 'react-native';
 import {checkNotifications, requestNotifications} from 'react-native-permissions';
 import {
   SystemStatus,
-  useExposureNotificationListener,
+  useExposureNotificationSystemStatusAutomaticUpdater,
   useExposureStatus,
   useStartExposureNotificationService,
   useSystemStatus,
@@ -53,12 +53,6 @@ const useNotificationPermissionStatus = (): [string, () => void] => {
 const Content = () => {
   const [exposureStatus] = useExposureStatus();
   const [systemStatus] = useSystemStatus();
-  const startExposureNotificationService = useStartExposureNotificationService();
-
-  useEffect(() => {
-    startExposureNotificationService();
-  }, [startExposureNotificationService]);
-
   const network = useNetInfo();
 
   switch (exposureStatus.type) {
@@ -76,8 +70,9 @@ const Content = () => {
         case SystemStatus.BluetoothOff:
           return <BluetoothDisabledView />;
         case SystemStatus.Active:
-        case SystemStatus.Unknown:
           return <NoExposureView />;
+        default:
+          return null;
       }
   }
 };
@@ -92,10 +87,17 @@ export const HomeScreen = () => {
     }
   }, [navigation]);
 
-  const exposureNotificationListener = useExposureNotificationListener();
+  // This only initiate system status updater.
+  // The actual updates will be delivered in useSystemStatus().
+  const subscribeToStatusUpdates = useExposureNotificationSystemStatusAutomaticUpdater();
   useEffect(() => {
-    return exposureNotificationListener();
-  }, [exposureNotificationListener]);
+    return subscribeToStatusUpdates();
+  }, [subscribeToStatusUpdates]);
+
+  const startExposureNotificationService = useStartExposureNotificationService();
+  useEffect(() => {
+    startExposureNotificationService();
+  }, [startExposureNotificationService]);
 
   const [systemStatus] = useSystemStatus();
   const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-atomic-updates */
 import {when} from 'jest-when';
 
-import {ExposureNotificationService, SystemStatus} from './ExposureNotificationService';
+import {ExposureNotificationService} from './ExposureNotificationService';
 
 const server: any = {
   retrieveDiagnosisKeys: jest.fn().mockResolvedValue(null),
@@ -22,7 +22,6 @@ const bridge: any = {
   detectExposure: jest.fn().mockResolvedValue({matchedKeyCount: 0}),
   start: jest.fn().mockResolvedValue(undefined),
   getTemporaryExposureKeyHistory: jest.fn().mockResolvedValue({}),
-  getStatus: jest.fn().mockResolvedValue(SystemStatus.Active),
 };
 
 describe('ExposureNotificationService', () => {
@@ -124,7 +123,6 @@ describe('ExposureNotificationService', () => {
       args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-19T04:10:00+0000'),
     );
 
-    await service.init();
     await service.start();
 
     expect(service.exposureStatus.get()).toStrictEqual(
@@ -149,7 +147,6 @@ describe('ExposureNotificationService', () => {
         .calledWith('submissionLastCompletedAt')
         .mockResolvedValue(new OriginalDate('2020-05-18T04:10:00+0000').toString());
 
-      await service.init();
       await service.start();
       expect(service.exposureStatus.get()).toStrictEqual(
         expect.objectContaining({
@@ -161,7 +158,6 @@ describe('ExposureNotificationService', () => {
       when(storage.getItem)
         .calledWith('submissionLastCompletedAt')
         .mockResolvedValue(new OriginalDate('2020-05-19T04:10:00+0000').getTime().toString());
-      await service.init();
       await service.start();
       expect(service.exposureStatus.get()).toStrictEqual(
         expect.objectContaining({
@@ -185,7 +181,6 @@ describe('ExposureNotificationService', () => {
       args.length > 0 ? new OriginalDate(...args) : new OriginalDate(currentDateString),
     );
 
-    await service.init();
     await service.start();
     await service.updateExposureStatus();
     expect(service.exposureStatus.get()).toStrictEqual(

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-atomic-updates */
 import {when} from 'jest-when';
 
-import {ExposureNotificationService} from './ExposureNotificationService';
+import {ExposureNotificationService, LAST_CHECK_TIMESTAMP} from './ExposureNotificationService';
 
 const server: any = {
   retrieveDiagnosisKeys: jest.fn().mockResolvedValue(null),
@@ -22,6 +22,7 @@ const bridge: any = {
   detectExposure: jest.fn().mockResolvedValue({matchedKeyCount: 0}),
   start: jest.fn().mockResolvedValue(undefined),
   getTemporaryExposureKeyHistory: jest.fn().mockResolvedValue({}),
+  getStatus: jest.fn().mockResolvedValue('active'),
 };
 
 describe('ExposureNotificationService', () => {
@@ -86,11 +87,11 @@ describe('ExposureNotificationService', () => {
     });
 
     when(storage.getItem)
-      .calledWith('lastCheckTimeStamp')
+      .calledWith(LAST_CHECK_TIMESTAMP)
       .mockResolvedValue(new OriginalDate('2020-05-18T04:10:00+0000').getTime());
 
     await service.updateExposureStatus();
-    expect(storage.setItem).toHaveBeenCalledWith('lastCheckTimeStamp', `${currentDatetime.getTime()}`);
+    expect(storage.setItem).toHaveBeenCalledWith(LAST_CHECK_TIMESTAMP, `${currentDatetime.getTime()}`);
   });
 
   it('enters Diagnosed flow when start keys submission process', async () => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-atomic-updates */
 import {when} from 'jest-when';
 
-import {ExposureNotificationService} from './ExposureNotificationService';
+import {ExposureNotificationService, SystemStatus} from './ExposureNotificationService';
 
 const server: any = {
   retrieveDiagnosisKeys: jest.fn().mockResolvedValue(null),
@@ -22,6 +22,7 @@ const bridge: any = {
   detectExposure: jest.fn().mockResolvedValue({matchedKeyCount: 0}),
   start: jest.fn().mockResolvedValue(undefined),
   getTemporaryExposureKeyHistory: jest.fn().mockResolvedValue({}),
+  getStatus: jest.fn().mockResolvedValue(SystemStatus.Active),
 };
 
 describe('ExposureNotificationService', () => {
@@ -123,6 +124,7 @@ describe('ExposureNotificationService', () => {
       args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-19T04:10:00+0000'),
     );
 
+    await service.init();
     await service.start();
 
     expect(service.exposureStatus.get()).toStrictEqual(
@@ -147,6 +149,7 @@ describe('ExposureNotificationService', () => {
         .calledWith('submissionLastCompletedAt')
         .mockResolvedValue(new OriginalDate('2020-05-18T04:10:00+0000').toString());
 
+      await service.init();
       await service.start();
       expect(service.exposureStatus.get()).toStrictEqual(
         expect.objectContaining({
@@ -158,6 +161,7 @@ describe('ExposureNotificationService', () => {
       when(storage.getItem)
         .calledWith('submissionLastCompletedAt')
         .mockResolvedValue(new OriginalDate('2020-05-19T04:10:00+0000').getTime().toString());
+      await service.init();
       await service.start();
       expect(service.exposureStatus.get()).toStrictEqual(
         expect.objectContaining({
@@ -181,6 +185,7 @@ describe('ExposureNotificationService', () => {
       args.length > 0 ? new OriginalDate(...args) : new OriginalDate(currentDateString),
     );
 
+    await service.init();
     await service.start();
     await service.updateExposureStatus();
     expect(service.exposureStatus.get()).toStrictEqual(

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -84,7 +84,19 @@ export class ExposureNotificationService {
     this.secureStorage = secureStorage;
   }
 
-  async init() {
+  async start(): Promise<void> {
+    if (this.starting) {
+      return;
+    }
+    this.starting = true;
+
+    try {
+      await this.exposureNotification.start();
+    } catch (_) {
+      // Noop because Exposure Notification framework is unavailable on device
+      return;
+    }
+
     await this.updateSystemStatus();
 
     // we check the lastCheckTimeStamp on start to make sure it gets populated even if the server doesn't run
@@ -103,23 +115,7 @@ export class ExposureNotificationService {
     }
 
     await this.updateExposureStatus();
-  }
 
-  async start(): Promise<void> {
-    if (this.starting) {
-      return;
-    }
-    this.starting = true;
-
-    try {
-      await this.exposureNotification.start();
-    } catch (_) {
-      // Noop because Exposure Notification framework is unavailable on device
-      return;
-    }
-
-    await this.updateSystemStatus();
-    await this.updateExposureStatus();
     this.starting = false;
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -36,8 +36,6 @@ export const ExposureNotificationServiceProvider = ({
   children,
 }: ExposureNotificationServiceProviderProps) => {
   const [i18n] = useI18n();
-  const [ready, setReady] = useState(false);
-
   const exposureNotificationService = useMemo(
     () =>
       new ExposureNotificationService(
@@ -51,13 +49,6 @@ export const ExposureNotificationServiceProvider = ({
   );
 
   useEffect(() => {
-    (async () => {
-      await exposureNotificationService.init();
-      setReady(true);
-    })();
-  }, [exposureNotificationService]);
-
-  useEffect(() => {
     backgroundScheduler.registerPeriodicTask(() => {
       return exposureNotificationService.updateExposureStatusInBackground();
     });
@@ -65,7 +56,7 @@ export const ExposureNotificationServiceProvider = ({
 
   return (
     <ExposureNotificationServiceContext.Provider value={exposureNotificationService}>
-      {ready && children}
+      {children}
     </ExposureNotificationServiceContext.Provider>
   );
 };
@@ -124,7 +115,7 @@ export function useReportDiagnosis() {
   };
 }
 
-export function useExposureNotificationListener() {
+export function useExposureNotificationSystemStatusAutomaticUpdater() {
   const exposureNotificationService = useContext(ExposureNotificationServiceContext)!;
   return useCallback(() => {
     const updateStatus = async (newState: AppStateStatus) => {

--- a/src/types/react-native-system-setting.d.ts
+++ b/src/types/react-native-system-setting.d.ts
@@ -1,0 +1,13 @@
+declare module 'react-native-system-setting' {
+  interface Listener {
+    remove();
+  }
+
+  interface SystemSetting {
+    addBluetoothListener(callback: (enabled: boolean) => void): Promise<Listener>;
+  }
+
+  const systemSetting: SystemSetting;
+
+  export default systemSetting;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7235,6 +7235,11 @@ react-native-svg@^12.1.0:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
+react-native-system-setting@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/react-native-system-setting/-/react-native-system-setting-1.7.4.tgz#605fb21fe901e5d25f37b864326aaddde33e926b"
+  integrity sha512-hS97zoYI/pffiKWBx15X2e8y4srm8q2uCp3aO+49P+Hu3HMNi4BgOvAG+J7KRHdoKEnIapRoVV67pLQsLqjQzw==
+
 react-native@0.62.2:
   version "0.62.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.2.tgz#d831e11a3178705449142df19a70ac2ca16bad10"


### PR DESCRIPTION
This PR fixes system status initial state. The system status flashing issue is related to async loading in ExposureNotificationService. The initial value is Disable for systemStatus and Monitoring for expsoureStatus, then we call start to load actual data. I fixes it by separating init and start. 

Follow up of https://github.com/CovidShield/mobile/pull/138 and https://github.com/CovidShield/mobile/pull/139
Resolves https://github.com/cds-snc/covid-shield-mobile/issues/95

## How to test?
- Run the app. 
- Pull down notification bar, disable bluetooth.
- Verify that system status changes to Bluetooth turn off. 

<img src="https://user-images.githubusercontent.com/5274722/85392307-569a8b00-b519-11ea-8fda-853ba5f1d41e.gif" width="240"/>
