### PR TITLE
Fix locale behaviour so everything doesn't get rerendered on locale change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ const i18nManager = new I18nManager({
 const appInit = async () => {
   try {
     const locale = await AsyncStorage.getItem(Key.Locale);
-    if (locale) i18nManager.update({locale});
+    if (locale && locale !== i18nManager.details.locale) i18nManager.update({locale});
   } catch (error) {
     console.error(error);
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,41 +31,49 @@ if (__DEV__) {
     .connect();
 }
 
+const i18nManager = new I18nManager({
+  locale: 'en',
+  onError(error) {
+    console.log('>>> i18N', error);
+  },
+});
+
 const App = () => {
   useEffect(() => SplashScreen.hide(), []);
 
   const {locale} = useStorage();
-  const i18nManager = useMemo(
-    () =>
-      new I18nManager({
-        locale,
-        onError(error) {
-          console.log('>>> i18N', error);
-        },
-      }),
-    [locale],
-  );
-
-  const backendService = useMemo(() => new BackendService(RETRIEVE_URL, SUBMIT_URL, HMAC_KEY, REGION), []);
+  useEffect(() => {
+    i18nManager.update({locale});
+  }, [locale]);
 
   return (
     <I18nContext.Provider value={i18nManager}>
       <SharedTranslations>
-        <ExposureNotificationServiceProvider backendInterface={backendService}>
-          <DevPersistedNavigationContainer persistKey="navigationState">
-            {TEST_MODE ? (
-              <TestMode>
-                <MainNavigator />
-              </TestMode>
-            ) : (
-              <MainNavigator />
-            )}
-          </DevPersistedNavigationContainer>
-        </ExposureNotificationServiceProvider>
+        <MemoizedApp />
       </SharedTranslations>
     </I18nContext.Provider>
   );
 };
+
+const AppContent = () => {
+  const backendService = useMemo(() => new BackendService(RETRIEVE_URL, SUBMIT_URL, HMAC_KEY, REGION), []);
+
+  return (
+    <ExposureNotificationServiceProvider backendInterface={backendService}>
+      <DevPersistedNavigationContainer persistKey="navigationState">
+        {TEST_MODE ? (
+          <TestMode>
+            <MainNavigator />
+          </TestMode>
+        ) : (
+          <MainNavigator />
+        )}
+      </DevPersistedNavigationContainer>
+    </ExposureNotificationServiceProvider>
+  );
+};
+
+const MemoizedApp = React.memo(AppContent);
 
 const AppProvider = () => {
   return (

--- a/src/services/StorageService/StorageService.ts
+++ b/src/services/StorageService/StorageService.ts
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 import {Observable} from 'shared/Observable';
 import {Region} from 'shared/Region';
 
-enum Key {
+export enum Key {
   IsOnboarded = 'IsOnboarded',
   Locale = 'Locale',
   Region = 'Region',

--- a/src/services/StorageService/StorageServiceProvider.tsx
+++ b/src/services/StorageService/StorageServiceProvider.tsx
@@ -31,7 +31,7 @@ export const useStorage = () => {
   const setLocale = useMemo(
     () => (newLocale: string) => {
       storageService.setLocale(newLocale);
-      if (i18nManager && newLocale) i18nManager.update({locale: newLocale});
+      if (i18nManager && newLocale && newLocale !== i18nManager.details.locale) i18nManager.update({locale: newLocale});
     },
     [storageService, i18nManager],
   );

--- a/src/services/StorageService/StorageServiceProvider.tsx
+++ b/src/services/StorageService/StorageServiceProvider.tsx
@@ -1,5 +1,6 @@
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import AsyncStorage from '@react-native-community/async-storage';
+import {I18nContext} from '@shopify/react-i18n';
 import {DevSettings} from 'react-native';
 
 import {StorageService} from './StorageService';
@@ -21,12 +22,19 @@ export const StorageServiceProvider = ({children}: StorageServiceProviderProps) 
 
 export const useStorage = () => {
   const storageService = useContext(StorageServiceContext)!;
+  const i18nManager = React.useContext(I18nContext);
 
   const [isOnboarding, setIsOnboarding] = useState(storageService.isOnboarding.value);
   const setOnboarded = useMemo(() => storageService.setOnboarded, [storageService.setOnboarded]);
 
   const [locale, setLocaleInternal] = useState(storageService.locale.value);
-  const setLocale = useMemo(() => storageService.setLocale, [storageService.setLocale]);
+  const setLocale = useMemo(
+    () => (newLocale: string) => {
+      storageService.setLocale(newLocale);
+      if (i18nManager && newLocale) i18nManager.update({locale: newLocale});
+    },
+    [storageService, i18nManager],
+  );
 
   const [region, setRegionInternal] = useState(storageService.region.value);
   const setRegion = useMemo(() => storageService.setRegion, [storageService.setRegion]);


### PR DESCRIPTION
Functional component just rerenders everything by default when the useStorage hook changes, we don't want that here. Instead we only want to check for local from storage on app init and update it as needed from context.

Closes https://github.com/CovidShield/mobile/issues/146