### PR TITLE
Fix keyboard blocks button onClick

### DIFF
--- a/src/screens/datasharing/DataSharing.tsx
+++ b/src/screens/datasharing/DataSharing.tsx
@@ -42,7 +42,7 @@ export const DataSharingScreen = () => {
           navLabel={i18n.translate('DataUpload.Cancel')}
           onIconClicked={close}
         />
-        <ScrollView style={styles.flex}>
+        <ScrollView style={styles.flex} keyboardShouldPersistTaps="handled">
           {!isVerified && (
             <FormView value={codeValue} onChange={handleChange} onSuccess={handleVerify} onError={onError} />
           )}


### PR DESCRIPTION
This PR fixes keyboard blocks button onClick event which requires to tap on screen twice to submit event. 

Resolves https://github.com/CovidShield/mobile/issues/141