### PR TITLE
Refactor bottom sheet to support dynamic content

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -13,12 +13,12 @@ import {SheetContentsContainer} from './SheetContentsContainer';
 const {abs, sub, pow} = Animated;
 
 export interface BottomSheetProps {
-  collapsedContent?: React.ReactElement;
-  children?: React.ReactElement;
+  collapsed?: React.ComponentType;
+  content: React.ComponentType;
   extraContent?: boolean;
 }
 
-const BottomSheet = ({children, collapsedContent, extraContent}: BottomSheetProps) => {
+const BottomSheet = ({content: ContentComponent, collapsed: CollapsedComponent, extraContent}: BottomSheetProps) => {
   const bottomSheetPosition = useRef(new Animated.Value(1));
   const bottomSheetRef: React.Ref<BottomSheetRaw> = useRef(null);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -46,7 +46,7 @@ const BottomSheet = ({children, collapsedContent, extraContent}: BottomSheetProp
 
   const expandedContentWrapper = (
     <Animated.View style={{opacity: abs(sub(bottomSheetPosition.current, 1))}}>
-      {children}
+      <ContentComponent />
       <TouchableOpacity
         onPress={toggleExpanded}
         style={styles.collapseButton}
@@ -62,7 +62,7 @@ const BottomSheet = ({children, collapsedContent, extraContent}: BottomSheetProp
       <View style={styles.collapseContentHandleBar}>
         <Icon name="sheet-handle-bar" />
       </View>
-      {collapsedContent}
+      {CollapsedComponent ? <CollapsedComponent /> : null}
     </Animated.View>
   );
   const renderContent = useCallback(() => {

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useRef, useEffect} from 'react';
+import React, {useState, useCallback, useRef, useEffect, useMemo} from 'react';
 import {View, StyleSheet, TouchableOpacity, useWindowDimensions} from 'react-native';
 import Animated from 'react-native-reanimated';
 import {useSafeArea} from 'react-native-safe-area-context';
@@ -44,27 +44,34 @@ const BottomSheet = ({content: ContentComponent, collapsed: CollapsedComponent, 
     bottomSheetRef.current?.snapTo(isExpanded ? 0 : 1);
   }, [width, isExpanded]);
 
-  const expandedContentWrapper = (
-    <Animated.View style={{opacity: abs(sub(bottomSheetPosition.current, 1))}}>
-      <ContentComponent />
-      <TouchableOpacity
-        onPress={toggleExpanded}
-        style={styles.collapseButton}
-        accessibilityLabel={i18n.translate('BottomSheet.Collapse')}
-        accessibilityRole="button"
-      >
-        <Icon name="icon-chevron" />
-      </TouchableOpacity>
-    </Animated.View>
+  const expandedContentWrapper = useMemo(
+    () => (
+      <Animated.View style={{opacity: abs(sub(bottomSheetPosition.current, 1))}}>
+        <ContentComponent />
+        <TouchableOpacity
+          onPress={toggleExpanded}
+          style={styles.collapseButton}
+          accessibilityLabel={i18n.translate('BottomSheet.Collapse')}
+          accessibilityRole="button"
+        >
+          <Icon name="icon-chevron" />
+        </TouchableOpacity>
+      </Animated.View>
+    ),
+    [i18n, toggleExpanded],
   );
-  const collapsedContentWrapper = (
-    <Animated.View style={{...styles.collapseContent, opacity: pow(bottomSheetPosition.current, 2)}}>
-      <View style={styles.collapseContentHandleBar}>
-        <Icon name="sheet-handle-bar" />
-      </View>
-      {CollapsedComponent ? <CollapsedComponent /> : null}
-    </Animated.View>
+  const collapsedContentWrapper = useMemo(
+    () => (
+      <Animated.View style={{...styles.collapseContent, opacity: pow(bottomSheetPosition.current, 2)}}>
+        <View style={styles.collapseContentHandleBar}>
+          <Icon name="sheet-handle-bar" />
+        </View>
+        {CollapsedComponent ? <CollapsedComponent /> : null}
+      </Animated.View>
+    ),
+    [CollapsedComponent],
   );
+
   const renderContent = useCallback(() => {
     return (
       <SheetContentsContainer isExpanded={isExpanded} toggleExpanded={toggleExpanded}>

--- a/src/components/BottomSheet/SheetContentsContainer.tsx
+++ b/src/components/BottomSheet/SheetContentsContainer.tsx
@@ -20,12 +20,9 @@ export const SheetContentsContainer = ({children, isExpanded, toggleExpanded}: C
     </Box>
   );
 
-  if (isExpanded) {
-    return content;
-  }
-
   return (
     <TouchableHighlight
+      disabled={isExpanded}
       onPress={toggleExpanded}
       accessibilityRole="button"
       accessibilityLabel={

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -137,8 +137,6 @@ export const HomeScreen = () => {
     startExposureNotificationService();
   }, [startExposureNotificationService]);
 
-  const collapsedContent = useMemo(() => <CollapsedContent />, []);
-
   const [notificationStatus] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus !== 'granted';
   const maxWidth = useMaxContentWidth();
@@ -151,11 +149,10 @@ export const HomeScreen = () => {
       <BottomSheet
         // need to change the key here so bottom sheet is rerendered. This is because the snap points change.
         key={showNotificationWarning ? 'notifications-disabled' : 'notifications-enabled'}
-        collapsedContent={collapsedContent}
+        content={BottomSheetContent}
+        collapsed={CollapsedContent}
         extraContent={showNotificationWarning}
-      >
-        <BottomSheetContent />
-      </BottomSheet>
+      />
     </Box>
   );
 };

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {useNetInfo} from '@react-native-community/netinfo';
 import {DrawerActions, useNavigation} from '@react-navigation/native';
 import {BottomSheet, Box} from 'components';


### PR DESCRIPTION
BottomSheet we use take `renderContent` function, it's used for rendering content on demand. We used to give it statically rendered ReactElement, and when that element needs to change we would re-render the whole bottom sheet, which isn'r right: bottom sheet has animation and transitions side effects which clash with re-rendering. 
Instead, I give ComponentType to which will be used by bottom sheet to render content. Since it's component with no props, whenever it needs to update itself (based on system status change) it will only re-render itself, and bottom sheet structure will remain intact.