### PR TITLE
Fix SystemStatus indication when EN framework cannot start

### DIFF
--- a/src/bridge/ExposureNotification.ts
+++ b/src/bridge/ExposureNotification.ts
@@ -19,6 +19,8 @@ export enum RiskLevel {
 }
 
 export enum Status {
+  // .Undefined is made up status to indicate js client that status hasn't been received from EN framework
+  Undefined = 'undefined',
   Unknown = 'unknown',
   Active = 'active',
   Disabled = 'disabled',

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -66,6 +66,7 @@ const Content = () => {
       switch (systemStatus) {
         case SystemStatus.Disabled:
         case SystemStatus.Restricted:
+        case SystemStatus.Unknown:
           return <ExposureNotificationsDisabledView />;
         case SystemStatus.BluetoothOff:
           return <BluetoothDisabledView />;
@@ -82,7 +83,7 @@ const CollapsedContent = () => {
   const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus === 'denied';
 
-  if (systemStatus === SystemStatus.Unknown) {
+  if (systemStatus === SystemStatus.Undefined) {
     return null;
   }
 
@@ -101,7 +102,7 @@ const BottomSheetContent = () => {
   const showNotificationWarning = notificationStatus !== 'granted';
   const maxWidth = useMaxContentWidth();
 
-  if (systemStatus === SystemStatus.Unknown) {
+  if (systemStatus === SystemStatus.Undefined) {
     return null;
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -77,7 +77,7 @@ export class ExposureNotificationService {
   ) {
     this.translate = translate;
     this.exposureNotification = exposureNotification;
-    this.systemStatus = new Observable<SystemStatus>(SystemStatus.Unknown);
+    this.systemStatus = new Observable<SystemStatus>(SystemStatus.Undefined);
     this.exposureStatus = new Observable<ExposureStatus>({type: 'monitoring'});
     this.backendInterface = backendInterface;
     this.storage = storage;
@@ -93,7 +93,7 @@ export class ExposureNotificationService {
     try {
       await this.exposureNotification.start();
     } catch (_) {
-      // Noop because Exposure Notification framework is unavailable on device
+      this.systemStatus.set(SystemStatus.Unknown);
       return;
     }
 


### PR DESCRIPTION
This is relevant for simulator mostly, but also when app is run on devices without entitlements or provisioning.

The way it's done is by using explicit Undefined status to differentiate between 'unknown' status (reported by EN when it can't start for some reason) and between initial system status before framework returned anything.