### PR TITLE
Fix notification permission due to inconsistent state change

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -40,9 +40,10 @@ const BottomSheet = ({content: ContentComponent, collapsed: CollapsedComponent, 
   const {width, height} = useWindowDimensions();
   const snapPoints = [height, Math.max(width, height) * (extraContent ? 0.3 : 0.2)];
 
+  // Need to add snapPoints to set enough height when BottomSheet is collapsed
   useEffect(() => {
     bottomSheetRef.current?.snapTo(isExpanded ? 0 : 1);
-  }, [width, isExpanded]);
+  }, [width, isExpanded, snapPoints]);
 
   const expandedContentWrapper = useMemo(
     () => (

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -12,6 +12,10 @@ import {
 } from 'services/ExposureNotificationService';
 import {useMaxContentWidth} from 'shared/useMaxContentWidth';
 
+import {
+  NotificationPermissionStatusProvider,
+  useNotificationPermissionStatus,
+} from './components/NotificationPermissionStatus';
 import {BluetoothDisabledView} from './views/BluetoothDisabledView';
 import {CollapsedOverlayView} from './views/CollapsedOverlayView';
 import {DiagnosedShareView} from './views/DiagnosedShareView';
@@ -21,11 +25,6 @@ import {ExposureView} from './views/ExposureView';
 import {NetworkDisabledView} from './views/NetworkDisabledView';
 import {NoExposureView} from './views/NoExposureView';
 import {OverlayView} from './views/OverlayView';
-import {
-  useNotificationPermissionStatus,
-  NotificationPermissionStatusProvider,
-} from './components/NotificationPermissionStatus';
-import {getTimeZone} from 'react-native-localize';
 
 const Content = () => {
   const [exposureStatus] = useExposureStatus();

--- a/src/screens/home/components/NotificationPermissionStatus.tsx
+++ b/src/screens/home/components/NotificationPermissionStatus.tsx
@@ -1,0 +1,60 @@
+import React, {useMemo, useState, useEffect, useContext} from 'react';
+import {checkNotifications, requestNotifications} from 'react-native-permissions';
+import {createCancellableCallbackPromise} from 'shared/cancellablePromise';
+
+type Status = 'denied' | 'granted' | 'unavailable' | 'blocked';
+
+interface NotificationPermissionStatusContextProps {
+  status: Status;
+  request: () => void;
+}
+
+const noop: NotificationPermissionStatusContextProps['request'] = () => Promise.resolve('unavailable');
+
+const NotificationPermissionStatusContext = React.createContext<NotificationPermissionStatusContextProps>({} as any);
+
+interface NotificationPermissionStatusProviderProps {
+  children: React.ReactNode;
+}
+
+export const NotificationPermissionStatusProvider = ({children}: NotificationPermissionStatusProviderProps) => {
+  const [status, setStatus] = useState<NotificationPermissionStatusContextProps['status']>('granted');
+  const [request, setRequest] = useState<NotificationPermissionStatusContextProps['request']>(noop);
+
+  useEffect(() => {
+    const {callable, cancelable} = createCancellableCallbackPromise<Status>(
+      () =>
+        checkNotifications()
+          .then(({status}) => status)
+          .catch(() => 'unavailable'),
+      setStatus,
+    );
+    callable();
+    return cancelable;
+  }, []);
+
+  useEffect(() => {
+    const {callable, cancelable} = createCancellableCallbackPromise<Status>(
+      () =>
+        requestNotifications(['alert'])
+          .then(({status}) => status)
+          .catch(() => 'unavailable'),
+      setStatus,
+    );
+    setRequest(() => callable);
+    return cancelable;
+  }, []);
+
+  const props = useMemo(() => ({status, request}), [status, request]);
+
+  return (
+    <NotificationPermissionStatusContext.Provider value={props}>
+      {children}
+    </NotificationPermissionStatusContext.Provider>
+  );
+};
+
+export const useNotificationPermissionStatus: () => [Status, () => void] = () => {
+  const {status, request} = useContext(NotificationPermissionStatusContext);
+  return [status, request];
+};

--- a/src/shared/cancellablePromise.ts
+++ b/src/shared/cancellablePromise.ts
@@ -1,0 +1,32 @@
+type Cancellable = () => void;
+
+type Callback<T> = (result: T) => void;
+
+export function createCancellableCallbackPromise<T>(
+  nonExceptionCallback: () => Promise<T>,
+  callback: Callback<T>,
+): {cancelable: Cancellable; callable: () => void} {
+  let isCancelled = false;
+  const callable = () => {
+    (async () => {
+      try {
+        if (isCancelled) {
+          return;
+        }
+        const result = await nonExceptionCallback();
+        if (isCancelled) {
+          return;
+        }
+        callback(result);
+      } catch {
+        // Noop
+      }
+    })();
+  };
+  return {
+    callable,
+    cancelable: () => {
+      isCancelled = true;
+    },
+  };
+}


### PR DESCRIPTION
This PR fixes notification permission due to state change but there is no listener. After refactoring BottomSheet setup in HomeScreen, the notification permission status is out of sync between different part of the UI as there is no listener for state change. The fix is to create react Context to unify them. 

Resolves https://github.com/CovidShield/mobile/issues/159 and https://github.com/cds-snc/covid-shield-mobile/issues/161

### Before

https://drive.google.com/file/d/1TOD1Aym2ik0qGeJ8P1JMOOl8bDrs6KWI/view?usp=sharing

### After

https://drive.google.com/file/d/13YqPnphNpy9hTrdC1wAkwsK4lNWvrkn7/view?usp=sharing