### PR TITLE
Patch system-setting to not reference CLLocationManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "patch-package",
     "bundle-android": "yarn generate-translations && react-native bundle --dev false --platform android --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/",
     "bundle-ios": "yarn generate-translations && react-native bundle --dev false --platform ios --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios",
     "codegen-protobuf": "pbjs -t static-module -o src/services/BackendService/covidshield/covidshield.js src/services/BackendService/covidshield/covidshield.proto && pbts -o src/services/BackendService/covidshield/covidshield.d.ts src/services/BackendService/covidshield/covidshield.js",
@@ -76,6 +77,7 @@
     "jest": "25.1.0",
     "jest-when": "^2.7.1",
     "metro-react-native-babel-preset": "^0.58.0",
+    "patch-package": "^6.2.2",
     "prettier": "1.19.1",
     "prettier-eslint": "^9.0.0",
     "protobufjs": "^6.9.0",

--- a/patches/react-native-system-setting+1.7.4.patch
+++ b/patches/react-native-system-setting+1.7.4.patch
@@ -1,23 +1,21 @@
 diff --git a/node_modules/react-native-system-setting/ios/RTCSystemSetting.m b/node_modules/react-native-system-setting/ios/RTCSystemSetting.m
-index c94aaad..e2f44a7 100644
+index c94aaad..6099e57 100644
 --- a/node_modules/react-native-system-setting/ios/RTCSystemSetting.m
 +++ b/node_modules/react-native-system-setting/ios/RTCSystemSetting.m
-@@ -8,7 +8,7 @@
+@@ -8,7 +8,6 @@
  
  #import "RTCSystemSetting.h"
  #import <SystemConfiguration/CaptiveNetwork.h>
 -#import <CoreLocation/CoreLocation.h>
-+//#import <CoreLocation/CoreLocation.h>
  #import <CoreTelephony/CTTelephonyNetworkInfo.h>
  #import <ifaddrs.h>
  #import <net/if.h>
-@@ -122,7 +122,8 @@ +(BOOL)requiresMainQueueSetup{
+@@ -122,7 +121,7 @@ +(BOOL)requiresMainQueueSetup{
  }
  
  RCT_EXPORT_METHOD(isLocationEnabled:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
 -    resolve([NSNumber numberWithBool:[CLLocationManager locationServicesEnabled]]);
 +    resolve(@NO);
-+//    resolve([NSNumber numberWithBool:[CLLocationManager locationServicesEnabled]]);
  }
  
  RCT_EXPORT_METHOD(switchBluetooth){

--- a/patches/react-native-system-setting+1.7.4.patch
+++ b/patches/react-native-system-setting+1.7.4.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/react-native-system-setting/ios/RTCSystemSetting.m b/node_modules/react-native-system-setting/ios/RTCSystemSetting.m
+index c94aaad..e2f44a7 100644
+--- a/node_modules/react-native-system-setting/ios/RTCSystemSetting.m
++++ b/node_modules/react-native-system-setting/ios/RTCSystemSetting.m
+@@ -8,7 +8,7 @@
+ 
+ #import "RTCSystemSetting.h"
+ #import <SystemConfiguration/CaptiveNetwork.h>
+-#import <CoreLocation/CoreLocation.h>
++//#import <CoreLocation/CoreLocation.h>
+ #import <CoreTelephony/CTTelephonyNetworkInfo.h>
+ #import <ifaddrs.h>
+ #import <net/if.h>
+@@ -122,7 +122,8 @@ +(BOOL)requiresMainQueueSetup{
+ }
+ 
+ RCT_EXPORT_METHOD(isLocationEnabled:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
+-    resolve([NSNumber numberWithBool:[CLLocationManager locationServicesEnabled]]);
++    resolve(@NO);
++//    resolve([NSNumber numberWithBool:[CLLocationManager locationServicesEnabled]]);
+ }
+ 
+ RCT_EXPORT_METHOD(switchBluetooth){

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,6 +1718,11 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
@@ -4110,6 +4115,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -4175,6 +4188,24 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -5609,6 +5640,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -6748,6 +6786,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-case@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-2.1.1.tgz#94b8037c372d3fe2906e465bb45e25d226e8eea5"
@@ -7609,7 +7665,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4:
+rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==


### PR DESCRIPTION
system-setting library checks many different APIs for if it's enabled or not, including `CLLocationManager`.
Although there is never an attempt to ENABLE location services, apple may statically check _any_ references to CLLocationManager symbol and flag this activity. 

Solved to excluding this API reference (and statically returning NO instead of `[CLLocationManager isEnabled]`. Since this requires modification of a library code, patched it using `patch-package`. 