### PR TITLE
Fix notification permission initial state

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -57,7 +57,7 @@ const Content = () => {
 const CollapsedContent = () => {
   const [systemStatus] = useSystemStatus();
   const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
-  const showNotificationWarning = notificationStatus === 'denied';
+  const showNotificationWarning = notificationStatus !== 'granted';
 
   if (systemStatus === SystemStatus.Undefined) {
     return null;


### PR DESCRIPTION
This PR fixes notification permission initial state.
- `noop` is passed through `useState` in a wrong way.
- Optimize useEffect to prevent NotificationPermissionStatusContext.Provider children is re-rendered. 
- Fixed CollapsedContent.