### PR TITLE
Fix crash on attempt to use translate in ExposureNotificationService 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ BackgroundScheduler.registerAndroidHeadlessPeriodicTask(async () => {
   const i18n = await getBackgroundI18n();
   const exposureNotificationService = new ExposureNotificationService(
     backendService,
-    i18n.translate,
+    i18n,
     AsyncStorage,
     SecureStorage,
     ExposureNotification,

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -9,7 +9,9 @@ const server: any = {
   claimOneTimeCode: jest.fn(),
   reportDiagnosisKeys: jest.fn(),
 };
-const translate: any = {};
+const i18n: any = {
+  translate: jest.fn().mockReturnValue('foo'),
+};
 const storage: any = {
   getItem: jest.fn().mockResolvedValue(null),
   setItem: jest.fn().mockResolvedValueOnce(undefined),
@@ -31,7 +33,7 @@ describe('ExposureNotificationService', () => {
   const OriginalDate = global.Date;
   const dateSpy = jest.spyOn(global, 'Date');
   beforeEach(() => {
-    service = new ExposureNotificationService(server, translate, storage, secureStorage, bridge);
+    service = new ExposureNotificationService(server, i18n, storage, secureStorage, bridge);
   });
 
   afterEach(() => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -3,6 +3,7 @@ import ExposureNotification from 'bridge/ExposureNotification';
 import PushNotification from 'bridge/PushNotification';
 import {Observable} from 'shared/Observable';
 import {addDays, daysBetween, periodSinceEpoch} from 'shared/date-fns';
+import {I18n} from '@shopify/react-i18n';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 
@@ -17,7 +18,6 @@ const SECURE_OPTIONS = {
 
 export const LAST_CHECK_TIMESTAMP = 'lastCheckTimeStamp';
 
-type Translate = (key: string) => string;
 const hoursPerPeriod = 24;
 
 export {SystemStatus};
@@ -63,7 +63,7 @@ export class ExposureNotificationService {
   private exposureNotification: typeof ExposureNotification;
   private backendInterface: BackendInterface;
 
-  private translate: Translate;
+  private i18n: I18n;
   private storage: PersistencyProvider;
   private secureStorage: SecurePersistencyProvider;
 
@@ -71,12 +71,12 @@ export class ExposureNotificationService {
 
   constructor(
     backendInterface: BackendInterface,
-    translate: Translate,
+    i18n: I18n,
     storage: PersistencyProvider,
     secureStorage: SecurePersistencyProvider,
     exposureNotification: typeof ExposureNotification,
   ) {
-    this.translate = translate;
+    this.i18n = i18n;
     this.exposureNotification = exposureNotification;
     this.systemStatus = new Observable<SystemStatus>(SystemStatus.Undefined);
     this.exposureStatus = new Observable<ExposureStatus>({type: 'monitoring'});
@@ -130,15 +130,15 @@ export class ExposureNotificationService {
     const status = await this.updateExposureStatus();
     if (status.type === 'exposed') {
       PushNotification.presentLocalNotification({
-        alertTitle: this.translate('Notification.ExposedMessageTitle'),
-        alertBody: this.translate('Notification.ExposedMessageBody'),
+        alertTitle: this.i18n.translate('Notification.ExposedMessageTitle'),
+        alertBody: this.i18n.translate('Notification.ExposedMessageBody'),
       });
     }
 
     if (status.type === 'diagnosed' && status.needsSubmission) {
       PushNotification.presentLocalNotification({
-        alertTitle: this.translate('Notification.DailyUploadNotificationTitle'),
-        alertBody: this.translate('Notification.DailyUploadNotificationBody'),
+        alertTitle: this.i18n.translate('Notification.DailyUploadNotificationTitle'),
+        alertBody: this.i18n.translate('Notification.DailyUploadNotificationBody'),
       });
     }
   }

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -40,12 +40,12 @@ export const ExposureNotificationServiceProvider = ({
     () =>
       new ExposureNotificationService(
         backendInterface,
-        i18n.translate,
+        i18n,
         storage || AsyncStorage,
         secureStorage || SecureStorage,
         exposureNotification || ExposureNotification,
       ),
-    [backendInterface, exposureNotification, i18n.translate, secureStorage, storage],
+    [backendInterface, exposureNotification, i18n, secureStorage, storage],
   );
 
   useEffect(() => {


### PR DESCRIPTION
they way to stripped `translate` out of i18n made it unusable, attempt to call that `translate` later caused runtime crash (complaining about undefined `this.onError`.