### PR TITLE
Fix lastChecked for exposed status

### DIFF
--- a/src/components/LastCheckedDisplay.tsx
+++ b/src/components/LastCheckedDisplay.tsx
@@ -8,9 +8,9 @@ import {pluralizeKey} from 'shared/pluralization';
 export const LastCheckedDisplay = () => {
   const [i18n] = useI18n();
   const [exposureStatus] = useExposureStatus();
-  if (!exposureStatus.lastChecked) return null;
+  if (!exposureStatus.lastCheckedTimestamp) return null;
 
-  const lastCheckedDate = new Date(exposureStatus.lastChecked);
+  const lastCheckedDate = new Date(exposureStatus.lastCheckedTimestamp);
   const daysDiff = daysFromNow(lastCheckedDate);
   const hoursDiff = hoursFromNow(lastCheckedDate);
   const minutesDiff = Math.max(minutesFromNow(lastCheckedDate), 1);

--- a/src/components/LastCheckedDisplay.tsx
+++ b/src/components/LastCheckedDisplay.tsx
@@ -8,9 +8,9 @@ import {pluralizeKey} from 'shared/pluralization';
 export const LastCheckedDisplay = () => {
   const [i18n] = useI18n();
   const [exposureStatus] = useExposureStatus();
-  if (!exposureStatus.lastCheckedTimestamp) return null;
+  if (!exposureStatus.lastChecked?.timestamp) return null;
 
-  const lastCheckedDate = new Date(exposureStatus.lastCheckedTimestamp);
+  const lastCheckedDate = new Date(exposureStatus.lastChecked?.timestamp);
   const daysDiff = daysFromNow(lastCheckedDate);
   const hoursDiff = hoursFromNow(lastCheckedDate);
   const minutesDiff = Math.max(minutesFromNow(lastCheckedDate), 1);

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -92,8 +92,10 @@ describe('ExposureNotificationService', () => {
     });
 
     service.exposureStatus.append({
-      lastCheckedTimestamp: new OriginalDate('2020-05-19T06:10:00+0000').getTime(),
-      lastCheckedPeriod: periodSinceEpoch(new OriginalDate('2020-05-19T06:10:00+0000'), HOURS_PER_PERIOD),
+      lastChecked: {
+        timestamp: new OriginalDate('2020-05-19T06:10:00+0000').getTime(),
+        period: periodSinceEpoch(new OriginalDate('2020-05-19T06:10:00+0000'), HOURS_PER_PERIOD),
+      },
     });
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(0);
@@ -101,8 +103,10 @@ describe('ExposureNotificationService', () => {
     server.retrieveDiagnosisKeys.mockClear();
 
     service.exposureStatus.append({
-      lastCheckedTimestamp: new OriginalDate('2020-05-18T05:10:00+0000').getTime(),
-      lastCheckedPeriod: periodSinceEpoch(new OriginalDate('2020-05-18T05:10:00+0000'), HOURS_PER_PERIOD),
+      lastChecked: {
+        timestamp: new OriginalDate('2020-05-18T05:10:00+0000').getTime(),
+        period: periodSinceEpoch(new OriginalDate('2020-05-18T05:10:00+0000'), HOURS_PER_PERIOD),
+      },
     });
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
@@ -110,8 +114,10 @@ describe('ExposureNotificationService', () => {
     server.retrieveDiagnosisKeys.mockClear();
 
     service.exposureStatus.append({
-      lastCheckedTimestamp: new OriginalDate('2020-05-17T23:10:00+0000').getTime(),
-      lastCheckedPeriod: periodSinceEpoch(new OriginalDate('2020-05-17T23:10:00+0000'), HOURS_PER_PERIOD),
+      lastChecked: {
+        timestamp: new OriginalDate('2020-05-17T23:10:00+0000').getTime(),
+        period: periodSinceEpoch(new OriginalDate('2020-05-17T23:10:00+0000'), HOURS_PER_PERIOD),
+      },
     });
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);
@@ -132,8 +138,10 @@ describe('ExposureNotificationService', () => {
     });
 
     service.exposureStatus.append({
-      lastCheckedTimestamp: new OriginalDate('2020-05-18T04:10:00+0000').getTime(),
-      lastCheckedPeriod: periodSinceEpoch(new OriginalDate('2020-05-18T04:10:00+0000'), HOURS_PER_PERIOD),
+      lastChecked: {
+        timestamp: new OriginalDate('2020-05-18T04:10:00+0000').getTime(),
+        period: periodSinceEpoch(new OriginalDate('2020-05-18T04:10:00+0000'), HOURS_PER_PERIOD),
+      },
     });
 
     const currentPeriod = periodSinceEpoch(currentDatetime, HOURS_PER_PERIOD);
@@ -146,8 +154,10 @@ describe('ExposureNotificationService', () => {
     expect(storage.setItem).toHaveBeenCalledWith(
       EXPOSURE_STATUS,
       expect.jsonStringContaining({
-        lastCheckedTimestamp: currentDatetime.getTime(),
-        lastCheckedPeriod: currentPeriod - 1,
+        lastChecked: {
+          timestamp: currentDatetime.getTime(),
+          period: currentPeriod - 1,
+        },
       }),
     );
   });


### PR DESCRIPTION
This PR splits lastChecked to `lastCheckedTimestamp` for displaying UI and `lastCheckedPeriod` for actual server request. 

Resolves https://github.com/CovidShield/mobile/issues/193

🎩-ed 

![image](https://user-images.githubusercontent.com/5274722/86385614-8a368d00-bc5e-11ea-8826-02d5c848734e.png)
