### PR TITLE
Fix padding in region picker

### DIFF
--- a/src/screens/regionPicker/RegionPicker.tsx
+++ b/src/screens/regionPicker/RegionPicker.tsx
@@ -72,7 +72,7 @@ export const RegionPickerScreen = () => {
     <Box flex={1} backgroundColor="overlayBackground">
       <SafeAreaView style={styles.flex}>
         <ScrollView style={styles.flex}>
-          <Box flex={1} paddingHorizontal="m" paddingTop="m">
+          <Box flex={1} paddingHorizontal="m" paddingTop="m" paddingBottom="m">
             <Text variant="bodySubTitle" color="overlayBodyText" textAlign="center" accessibilityRole="header">
               {i18n.translate('RegionPicker.Title')}
             </Text>


### PR DESCRIPTION
I didn't see similar issue in our repo but it's good to fix padding bottom.

Cherry-pick https://github.com/cds-snc/covid-shield-mobile/pull/385