### PR TITLE
Fix accessibility in carousel

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,16 +1,18 @@
-import React, {ReactNode} from 'react';
-import {createText} from '@shopify/restyle';
-import {Text as RNText, TextProps as RNTextProps} from 'react-native';
+import React, {forwardRef} from 'react';
+import {TextProps as RestyleTextProps, textRestyleFunctions, useRestyle} from '@shopify/restyle';
+import {Text as RNText} from 'react-native';
 import {Theme} from 'shared/theme';
 
-// Wrap text to set the correct font family based on weight on Android
-const _Text = ({style, ...rest}: RNTextProps & {children?: ReactNode}) => {
-  // const {fontFamily, fontWeight} = StyleSheet.flatten(style);
-  return <RNText style={[style]} {...rest} />;
+// See https://github.com/Shopify/restyle/blob/master/src/createText.ts
+export type TextProps = RestyleTextProps<Theme> &
+  Omit<React.ComponentProps<typeof RNText> & {children?: React.ReactNode}, keyof RestyleTextProps<Theme>>;
+
+const BaseText = (props: TextProps, ref?: React.LegacyRef<any>) => {
+  const styledProps = useRestyle(textRestyleFunctions, props);
+  return <RNText {...styledProps} ref={ref} />;
 };
 
-export const Text = createText<Theme>(_Text);
-export type TextProps = React.ComponentProps<typeof Text>;
+export const Text = forwardRef(BaseText);
 
 Text.defaultProps = {
   variant: 'bodyText',

--- a/src/screens/tutorial/Tutorial.tsx
+++ b/src/screens/tutorial/Tutorial.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useCallback, useRef} from 'react';
-import {StyleSheet, useWindowDimensions} from 'react-native';
-import Carousel, {CarouselStatic} from 'react-native-snap-carousel';
+import {StyleSheet, useWindowDimensions, View} from 'react-native';
+import Carousel, {CarouselStatic, CarouselProps} from 'react-native-snap-carousel';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Button, ProgressCircles, Toolbar} from 'components';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -15,22 +15,17 @@ export const TutorialScreen = () => {
   const [currentStep, setCurrentStep] = useState(0);
   const [i18n] = useI18n();
   const close = useCallback(() => navigation.goBack(), [navigation]);
-  const [carouselVisible, setCarousalVisible] = useState(false);
-
-  React.useEffect(() => {
-    const unsubscribe = navigation.addListener('focus', () => {
-      setCarousalVisible(true);
-    });
-
-    return unsubscribe;
-  }, [navigation]);
 
   const isStart = currentStep === 0;
   const isEnd = currentStep === tutorialData.length - 1;
 
-  const renderItem = useCallback(
-    ({item}: {item: TutorialKey}) => {
-      return <TutorialContent item={item} isActiveSlide={tutorialData[currentStep] === item} />;
+  const renderItem = useCallback<CarouselProps<TutorialKey>['renderItem']>(
+    ({item, index}) => {
+      return (
+        <View style={styles.flex} accessibilityElementsHidden={index !== currentStep}>
+          <TutorialContent item={item} isActive={tutorialData[currentStep] === item} />
+        </View>
+      );
     },
     [currentStep],
   );
@@ -61,16 +56,16 @@ export const TutorialScreen = () => {
           navLabel={i18n.translate('Tutorial.Close')}
           onIconClicked={close}
         />
-        {carouselVisible && (
-          <Carousel
-            ref={carouselRef}
-            data={tutorialData}
-            renderItem={renderItem}
-            sliderWidth={viewportWidth}
-            itemWidth={viewportWidth}
-            onSnapToItem={newIndex => setCurrentStep(newIndex)}
-          />
-        )}
+        <Carousel
+          ref={carouselRef}
+          data={tutorialData}
+          renderItem={renderItem}
+          sliderWidth={viewportWidth}
+          itemWidth={viewportWidth}
+          onSnapToItem={newIndex => setCurrentStep(newIndex)}
+          importantForAccessibility="no"
+          accessible={false}
+        />
         <Box flexDirection="row" padding="l">
           <Box flex={1}>
             {!isStart && (


### PR DESCRIPTION
Cherry-pick https://github.com/cds-snc/covid-shield-mobile/pull/496 and https://github.com/cds-snc/covid-shield-mobile/pull/392/files

It also fixes auto focus accessibility in Text component

## Expected result:
Accessibility is scoped to page, not screen. That means when accessibility is on, user cannot swipe to next screen. They need to press next button.