### PR TITLE
Handling the `reject` of getRandomBytes for iOS

### DIFF
--- a/ios/CovidShield/CovidShield.m
+++ b/ios/CovidShield/CovidShield.m
@@ -15,11 +15,14 @@ RCT_REMAP_METHOD(getRandomBytes, randomBytesWithSize:(NSUInteger)size withResolv
 {
   void *buff = malloc(size);
   int status = SecRandomCopyBytes(kSecRandomDefault, size, buff);
-  if (status == 0) {
+  free(buff);
+  if (status == errSecSuccess) {
     NSString *base64encoded = [[[NSData alloc] initWithBytes:buff length:size] base64EncodedStringWithOptions:0];
     resolve(base64encoded);
+  } else {
+    NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:status userInfo:nil];
+    reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
   }
-  free(buff);
 }
 
 RCT_REMAP_METHOD(downloadDiagnosisKeysFile, downloadDiagnosisKeysFileWithURL:(NSString *)url WithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
Cherry-pick https://github.com/cds-snc/covid-shield-mobile/pull/524 but only for iOS.