### PR TITLE
Adding `cache-control` headers to fetch / blobFetch requests. (Fixed)

### DIFF
--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -12,7 +12,7 @@ import {covidshield} from './covidshield';
 import {BackendInterface, SubmissionKeySet} from './types';
 
 const MAX_UPLOAD_KEYS = 14;
-const FETCH_HEADERS = {headers: {'Cache-Control': 'no-cache, no-store, must-revalidate'}};
+const FETCH_HEADERS = {headers: {'Cache-Control': 'no-store'}};
 
 export class BackendService implements BackendInterface {
   retrieveUrl: string;

--- a/src/shared/fetch.ts
+++ b/src/shared/fetch.ts
@@ -1,7 +1,6 @@
 export function blobFetch(uri: string, method: 'GET' | 'POST', body?: Uint8Array): Promise<ArrayBuffer> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.setRequestHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
     xhr.onload = function() {
       if (xhr.status >= 200 && xhr.status <= 299) {
         resolve(xhr.response);
@@ -19,6 +18,7 @@ export function blobFetch(uri: string, method: 'GET' | 'POST', body?: Uint8Array
 
     xhr.open(method, uri, true);
     xhr.setRequestHeader('Content-Type', 'application/x-protobuf');
+    xhr.setRequestHeader('Cache-Control', 'no-store');
     xhr.send(body || null);
   });
 }


### PR DESCRIPTION
Cherry-pick https://github.com/cds-snc/covid-shield-mobile/pull/546